### PR TITLE
Ignore JS files in pages folder

### DIFF
--- a/.nuxtignore
+++ b/.nuxtignore
@@ -1,0 +1,2 @@
+pages/news-and-events/model.js
+pages/resources/utils.js


### PR DESCRIPTION
In some cases, nuxt tries to render the js files in pages folder. They should be ignored instead. This issue can be replicated by running yarn generate.