### PR TITLE
Fixed selected facet ids bug

### DIFF
--- a/components/FacetMenu/DatasetFacetMenu.vue
+++ b/components/FacetMenu/DatasetFacetMenu.vue
@@ -183,7 +183,8 @@ export default {
       this.$router.replace({
         query: {
           ...this.$route.query,
-          selectedFacetIds: selectedFacetIds
+          selectedFacetIds: selectedFacetIds,
+          skip: 0
         }
       }).then(() => {
         this.latestUpdateId = data.id;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "plyr": "^3.7.8",
     "postscribe": "^2.0.8",
     "ramda": "^0.29.0",
-    "sparc-design-system-components-2": "0.0.25",
+    "sparc-design-system-components-2": "0.0.26",
     "striptags": "^3.2.0",
     "uint8array-extras": "^1.0.0",
     "vue-chartjs": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14574,10 +14574,10 @@ source-map@^0.7.4:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
-sparc-design-system-components-2@0.0.25:
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/sparc-design-system-components-2/-/sparc-design-system-components-2-0.0.25.tgz#71802da40061e8d38805eb1492c3ad924c25742a"
-  integrity sha512-9dDbkp7boiOApWwbGsPf78737a/uFApCrnBqQiJH1HKrrKqYvwoMaJyuu0RcpEnbJY4umTyc/Ozlju2ChV24uw==
+sparc-design-system-components-2@0.0.26:
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/sparc-design-system-components-2/-/sparc-design-system-components-2-0.0.26.tgz#943d71a00a97aa6c7701f559b2bcfccdc1fe40c1"
+  integrity sha512-BkJCd9SLgSs54EIp5nZxFMNS9bBdP2LYeF/cKh8of6dn65x2Eb61eJCYcNuNN3fa+EsZlkELtykPPr0vZ5UXwQ==
   dependencies:
     "@carbon/grid" "^11.20.0"
     "@element-plus/icons-vue" "^2.3.1"


### PR DESCRIPTION
There was a bug where the router.push(selectedIds) called from DatasetFacetMenu would get cancelled when selecting any heirarchal facets which would cause the query param to reset to undefined when the facet selection change handler was called in data/index.vue