### PR TITLE
Fix for file attachment not getting added

### DIFF
--- a/components/ContactUsForms/BugForm/BugForm.vue
+++ b/components/ContactUsForms/BugForm/BugForm.vue
@@ -35,14 +35,12 @@
       <div class="body4 mb-8"><i>To help others understand your issue an image can really help.</i></div>
       <el-upload
         ref="fileUploader"
-        action=""
+        action="#"
         :limit="limit"
+        :auto-upload="false"
         :on-change="onUploadChange"
         :on-remove="onRemove"
-        :before-remove="beforeRemove"
-        :on-success="onSuccess"
-        :on-error="onError"
-        :before-upload="beforeUpload"
+        :before-remove="beforeRemove" 
       >
         <template #trigger>
           <el-button class="secondary">Select file</el-button>
@@ -70,7 +68,7 @@
     <hr/>
 
     <el-form-item>
-      <el-button class="primary" :disabled="isSubmitting || uploadingFile" @click="onSubmit">
+      <el-button class="primary" :disabled="isSubmitting" @click="onSubmit">
         Submit
       </el-button>
       <p v-if="hasError" class="error">
@@ -115,7 +113,6 @@ export default {
           shouldSubscribe: false,
         }
       },
-      isUploading: false,
       isSubmitting: false,
       formRules: {
         user: {
@@ -236,8 +233,9 @@ export default {
       formData.append("description", description)
       formData.append("userEmail", this.form.user.email)
       formData.append("captcha_token", this.form.captchaToken)
-      if (propOr('', 'name', this.file) != ''){
-        formData.append("attachment", this.file, this.file.name)
+      if (fileName != '') {
+        const extension = fileName.substring(fileName.lastIndexOf('.')); 
+        formData.append("attachment", this.file, `attachment${extension}`)
       }
       // Save form to sessionStorage
       saveForm(this.form)

--- a/components/ContactUsForms/CommunitySpotlightForm/CommunitySpotlightForm.vue
+++ b/components/ContactUsForms/CommunitySpotlightForm/CommunitySpotlightForm.vue
@@ -25,14 +25,12 @@
       <div class="body4 mb-8"><i>To help others understand your story, an image can really help. We recommend images of 600px by 600px.</i></div>
       <el-upload
         ref="fileUploader"
-        action=""
+        action="#"
         :limit="limit"
+        :auto-upload="false"
         :on-change="onUploadChange"
         :on-remove="onRemove"
         :before-remove="beforeRemove"
-        :on-success="onSuccess"
-        :on-error="onError"
-        :before-upload="beforeUpload"
       >
         <template #trigger>
           <el-button class="secondary">Select file</el-button>

--- a/components/ContactUsForms/NewsAndEventsForm/NewsAndEventsForm.vue
+++ b/components/ContactUsForms/NewsAndEventsForm/NewsAndEventsForm.vue
@@ -25,15 +25,12 @@
       <div class="body4 mb-8"><i>To help others understand your news or event, an image can really help. We recommend images of 600px by 600px.</i></div>
       <el-upload
         ref="fileUploader"
-        action=""
+        action="#"
         :limit="limit"
         :auto-upload="false"
         :on-change="onUploadChange"
         :on-remove="onRemove"
         :before-remove="beforeRemove"
-        :on-success="onSuccess"
-        :on-error="onError"
-        :before-upload="beforeUpload"
       >
         <template #trigger>
           <el-button class="secondary">Select file</el-button>

--- a/mixins/file-upload/index.js
+++ b/mixins/file-upload/index.js
@@ -2,15 +2,13 @@ const kB_IN_MB = 1024;
 const MAX_FILE_SIZE_IN_MB = 5;
 const MAX_FILE_SIZE = kB_IN_MB * MAX_FILE_SIZE_IN_MB;
 import { failMessage } from '@/utils/notification-messages'
-import { isEmpty } from 'ramda'
 
 export default {
   data() {
     return {
       limit: 1,
       allowVideos: false,
-      file: {},
-      uploadingFile: false
+      file: {}
     }
   },
   computed: {
@@ -60,16 +58,13 @@ export default {
     onRemove() {
       this.file = {}
     },
-    beforeUpload()
+    beforeUpload(file)
     {
-      if (!isEmpty(this.file))
-        this.uploadingFile = true
-    },
-    onSuccess() {
-      this.uploadingFile = false
-    },
-    onError() {
-      this.uploadingFile = false
+      const isFileSizeTooLarge = this.isFileSizeTooLarge(file)
+      if (isFileSizeTooLarge) {
+        failMessage(`Upload file size cannot exceed ${MAX_FILE_SIZE_IN_MB} MB!`)
+      }
+      return !isFileSizeTooLarge
     }
   }
 }


### PR DESCRIPTION
The attachment was sometimes not being added due to certain characters in the filename. I updated the code to just always call the attached file 'attachment' so that we do not have to worry about sanitization especially since we already have the file name in the description of the wrike ticket