### PR TITLE
Remove mapviewer and simulationviewer as plugins

### DIFF
--- a/components/MapViewer/MapViewer.client.vue
+++ b/components/MapViewer/MapViewer.client.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="mapClass">
+    <MapContent class="map" ref="map" :state="state" :starting-map="startingMap" :options="options"
+        :share-link="shareLink" @updateShareLinkRequested="$emit('updateShareLinkRequested')" @isReady="$emit('isReady')" />
+  </div>
+</template>
+
+<script>
+  import { MapContent } from "@abi-software/mapintegratedvuer"
+  
+  export default {
+    name: 'MapViewer',
+    components: {
+      MapContent,
+    },
+    props: {
+      /**
+       * A link (URL) to share.
+       */
+      shareLink: {
+        type: String,
+        default: undefined
+      },
+      /**
+       * State containing state of the scaffold.
+       */
+      state: {
+        type: Object,
+        default: undefined
+      },
+      /**
+       * The options include APIs and Keys.
+       */
+      options: {
+        type: Object,
+        default: () => {},
+        required: true
+      },
+      /**
+       * New option to start the map in AC, FC or WholeBody.
+       */
+      startingMap: {
+        type: String,
+        default: "AC"
+      }
+    },
+    methods: {
+      getInstance: function(){
+        return this.$refs.map;
+      },
+    },
+  }
+</script>
+
+<style scope lang="scss">
+//@import 'sparc-design-system-components-2/src/assets/_variables.scss';
+@import '@abi-software/mapintegratedvuer/dist/style.css';
+@import '@abi-software/mapintegratedvuer/src/assets/mapicon-species-style.css';
+
+.mapClass {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border: solid 1px #dcdfe6;
+  box-shadow: 0 1px 8px 0 rgba(0, 0, 0, 0.06);
+
+  .map-icon {
+    color: #8300bf !important;
+  }
+
+  .background-popper.el-popover.el-popper,
+  .open-map-popper.el-popover.el-popper {
+    background: #fff !important;
+    width: unset !important;
+  }
+
+  .pathway-container {
+    .container {
+      padding-left: 0px;
+    }
+  }
+
+  .el-popover.right-popper {
+    .popper__arrow {
+      border-top-color: transparent !important;
+      border-bottom-color: transparent !important;
+    }
+  }
+}
+
+.gallery-popper {
+  background: #f3ecf6 !important;
+  border: 1px solid #8300bf;
+  border-radius: 4px;
+  color: #303133 !important;
+  font-size: 12px;
+  line-height: 1rem;
+  height: 1rem;
+  padding: 10px;
+
+  &.el-popper[x-placement^='top'] {
+    .popper__arrow {
+      border-top-color: #8300bf !important;
+    }
+
+    .popper__arrow:after {
+      border-top-color: #f3ecf6 !important;
+    }
+  }
+}
+</style>

--- a/components/SimulationViewer/SimulationViewer.client.vue
+++ b/components/SimulationViewer/SimulationViewer.client.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="simulation-vuer-container">
+    <simulation-vuer :apiLocation="apiLocation" :id="id" />
+  </div>
+</template>
+
+<script>
+  import { SimulationVuer } from '@abi-software/simulationvuer'
+  
+  export default {
+    name: 'SimulationViewer',
+    components: {
+      SimulationVuer,
+    },
+    props: {
+      /**
+       * The the URL to the API location.
+       */
+      apiLocation: {
+        required: true,
+        type: String,
+      },
+      /**
+       * The ID of the simulation-based dataset.
+       */
+      id: {
+        required: true,
+        type: Number,
+      },
+    },
+  }
+</script>
+
+<style scope lang="scss">
+@import '@abi-software/simulationvuer/dist/style.css';
+.simulation-vuer-container {
+  min-height: 24px;
+  overflow: hidden;
+}
+</style>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "sitemap": "^7.1.1"
   },
   "dependencies": {
-    "@abi-software/mapintegratedvuer": "1.0.1",
+    "@abi-software/mapintegratedvuer": "1.0.2",
     "@abi-software/plotvuer": "1.0.0",
     "@abi-software/simulationvuer": "1.0.0",
     "@element-plus/nuxt": "^1.0.6",

--- a/pages/apps/maps/index.vue
+++ b/pages/apps/maps/index.vue
@@ -14,12 +14,8 @@
       </p>
     </page-hero>
     <div ref="mappage" class="page-wrap portalmapcontainer">
-      <client-only placeholder="Loading components...">
-        <div class="mapClass">
-          <map-content class="map" ref="map" :state="state" :starting-map="startingMap" :options="options"
-            :share-link="shareLink" @updateShareLinkRequested="updateUUID" @isReady="mapMounted" />
-        </div>
-      </client-only>
+      <MapViewer class="mapviewer" ref="mapviewer" :state="state" :starting-map="startingMap" :options="options"
+        :share-link="shareLink" @updateShareLinkRequested="updateUUID" @isReady="mapMounted" />
     </div>
   </div>
 </template>
@@ -30,8 +26,6 @@ import flatmaps from '@/services/flatmaps'
 import scicrunch from '@/services/scicrunch'
 
 import FetchPennsieveFile from '@/mixins/fetch-pennsieve-file'
-
-import PortalFeatures from '@/components/PortalFeatures/PortalFeatures.vue'
 
 import { extractS3BucketName } from '@/utils/common'
 import { successMessage, failMessage } from '@/utils/notification-messages'
@@ -298,9 +292,6 @@ const openViewWithQuery = async (route, $axios, sparcApi, algoliaIndex, discover
 
 export default {
   name: 'MapsPage',
-  components: {
-    PortalFeatures,
-  },
   async setup() {
     const config = useRuntimeConfig()
     const { $algoliaClient, $axios, $pennsieveApiClient } = useNuxtApp()
@@ -415,7 +406,7 @@ export default {
   methods: {
     updateUUID: function () {
       let url = this.options.sparcApi + `map/getshareid`
-      let state = this.$refs.map.getState()
+      let state = this._instance.getState()
       fetch(url, {
         method: 'POST',
         headers: {
@@ -432,14 +423,15 @@ export default {
         })
     },
     facetsUpdated: function () {
-      if (this.facets.length > 0 && this.$refs.map) this.$refs.map.openSearch(this.facets, "")
+      if (this.facets.length > 0 && this._instance) this._instance.openSearch(this.facets, "")
     },
     currentEntryUpdated: function () {
-      if (this.$refs.map && this.currentEntry) {
-        this.$refs.map.setCurrentEntry(this.currentEntry)
+      if (this._instance && this.currentEntry) {
+        this._instance.setCurrentEntry(this.currentEntry)
       }
     },
     mapMounted: function () {
+      this._instance = this.$refs.mapviewer.getInstance();
       this.currentEntryUpdated()
       this.facetsUpdated()
     },
@@ -484,59 +476,6 @@ export default {
 
 <style lang="scss">
 //@import 'sparc-design-system-components-2/src/assets/_variables.scss';
-@import '@abi-software/mapintegratedvuer/dist/style.css';
 @import '@abi-software/mapintegratedvuer/src/assets/mapicon-species-style.css';
 
-
-.mapClass {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  border: solid 1px #dcdfe6;
-  box-shadow: 0 1px 8px 0 rgba(0, 0, 0, 0.06);
-
-  .map-icon {
-    color: #8300bf !important;
-  }
-
-  .background-popper.el-popover.el-popper,
-  .open-map-popper.el-popover.el-popper {
-    background: #fff !important;
-    width: unset !important;
-  }
-
-  .pathway-container {
-    .container {
-      padding-left: 0px;
-    }
-  }
-
-  .el-popover.right-popper {
-    .popper__arrow {
-      border-top-color: transparent !important;
-      border-bottom-color: transparent !important;
-    }
-  }
-}
-
-.gallery-popper {
-  background: #f3ecf6 !important;
-  border: 1px solid #8300bf;
-  border-radius: 4px;
-  color: #303133 !important;
-  font-size: 12px;
-  line-height: 1rem;
-  height: 1rem;
-  padding: 10px;
-
-  &.el-popper[x-placement^='top'] {
-    .popper__arrow {
-      border-top-color: #8300bf !important;
-    }
-
-    .popper__arrow:after {
-      border-top-color: #f3ecf6 !important;
-    }
-  }
-}
 </style>

--- a/pages/datasets/simulationviewer/index.vue
+++ b/pages/datasets/simulationviewer/index.vue
@@ -8,7 +8,7 @@
       >
         <client-only placeholder="Loading simulation ...">
           <div class="simulation-vuer-container">
-            <simulation-vuer :apiLocation="apiLocation" :id="id" />
+            <simulation-viewer :apiLocation="apiLocation" :id="id" />
           </div>
         </client-only>
       </content-tab-card>
@@ -37,11 +37,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss">
-@import '@abi-software/simulationvuer/dist/style.css';
-.simulation-vuer-container {
-  min-height: 24px;
-  overflow: hidden;
-}
-</style>

--- a/plugins/mapintegratedviewer.client.js
+++ b/plugins/mapintegratedviewer.client.js
@@ -1,6 +1,0 @@
-import { MapContent } from '@abi-software/mapintegratedvuer'
-
-export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.component("map-content", MapContent);
-})
-

--- a/plugins/simulationviewer.client.js
+++ b/plugins/simulationviewer.client.js
@@ -1,5 +1,0 @@
-import { SimulationVuer } from '@abi-software/simulationvuer'
-
-export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.component("simulation-vuer", SimulationVuer);
-})

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
     minisearch "^2.2.1"
     polylabel "^1.1.0"
 
-"@abi-software/flatmapvuer@1.0.0", "@abi-software/flatmapvuer@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.0.0.tgz#b2e9389d8cb204e55dfb0f21437d5d82753e5053"
-  integrity sha512-FCBQtVncTIMAhMyezTR1veUHTcX5qU5d8+TXZkSIrbBGyloTP+aA1nigPy6YURBXhcQ94uVLW//3YNxmZTJZ3g==
+"@abi-software/flatmapvuer@1.0.1", "@abi-software/flatmapvuer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.0.1.tgz#3291f7312489a042a33c606ab7ec07c81ba50141"
+  integrity sha512-D6Ydew2OL9Kes5SSKfmX4Wk+t7BCmUDEgRSlerUIMKG4Ne9jRW6cjT4sLCBK5h7xHPzHu+PmGotD0nf2FGpHLA==
   dependencies:
     "@abi-software/flatmap-viewer" "2.6.2"
     "@abi-software/sparc-annotation" "0.2.0"
@@ -56,7 +56,7 @@
     unplugin-vue-components "^0.26.0"
     vue "^3.3.13"
 
-"@abi-software/map-side-bar@^2.0.1":
+"@abi-software/map-side-bar@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-2.0.1.tgz#543f5d1e5cc5357cd08da9b7b2699164cd2d02c0"
   integrity sha512-y1zScjghjVKkQoUQvFffbzQmkCOKxtdGNKOTa1my3qHiugsR3UKdWPgh3gVoXIsXs+CD3AonwMWKdSwFLG3WSQ==
@@ -72,15 +72,15 @@
     vue "^3.3.13"
     xss "^1.0.14"
 
-"@abi-software/mapintegratedvuer@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.0.1.tgz#f638ed1746a56ff42f0907dd489a06c275826e8e"
-  integrity sha512-nV028qaLAIHcBpgK7FTqPLVss11uJobSVmhxTtdZi3oktYc4VJwNTIVzj/4nWhtB1ZZ0N3y8SB4f5IZ5cxz1bA==
+"@abi-software/mapintegratedvuer@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.0.2.tgz#dc00d014c9d14d839ad74735c166767db31cca50"
+  integrity sha512-iOeH9Suer6i38rPNzJCb/A7Mqx2479bwtNUmx/jB8A4aS7QjMlibnEeqNWFWXG7oDvuxJjEEN16ZdFyk9i2TxQ==
   dependencies:
-    "@abi-software/flatmapvuer" "1.0.0"
-    "@abi-software/map-side-bar" "^2.0.1"
+    "@abi-software/flatmapvuer" "1.0.1"
+    "@abi-software/map-side-bar" "2.0.1"
     "@abi-software/plotvuer" "1.0.0"
-    "@abi-software/scaffoldvuer" "^1.0.0"
+    "@abi-software/scaffoldvuer" "1.0.1"
     "@abi-software/simulationvuer" "1.0.0"
     "@abi-software/svg-sprite" "1.0.0"
     "@element-plus/icons-vue" "^2.3.1"
@@ -117,12 +117,12 @@
     vue-draggable-resizable "^2.2.0"
     vue-router "^4.2.5"
 
-"@abi-software/scaffoldvuer@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/scaffoldvuer/-/scaffoldvuer-1.0.0.tgz#19f4400fe9243f29a1a5d836d196f4cd4d3ee0a2"
-  integrity sha512-+OjWbfoCVsd+3h896hEmPCg5XkEUHBKL/IRwhqPdO6F5umCnkyx/eNDRWxMFNgd/n1lLcxmCi2V1rgq1Tz9zZg==
+"@abi-software/scaffoldvuer@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/scaffoldvuer/-/scaffoldvuer-1.0.1.tgz#a200407bd0385d541a7b3404672215fc601d74eb"
+  integrity sha512-w+RSgkhZnVg6OBawkkYftqAw176DAk2WtQ9xg1XQ1YBD/HnSY19nmgmC1iXkxv/ITztwJRDsYzVaA5eUxaRLOw==
   dependencies:
-    "@abi-software/flatmapvuer" "^1.0.0"
+    "@abi-software/flatmapvuer" "^1.0.1"
     "@abi-software/svg-sprite" "^1.0.0"
     "@element-plus/icons-vue" "^2.3.1"
     "@vue/compat" "^3.4.15"


### PR DESCRIPTION
Removed mapviewer and simulationviewer as plugins and reimplemented as client only component instead. This will cut the initial loading time of the Portal.

This can be tested here - https://alan-wu-sparc-app.herokuapp.com/