### PR TITLE
Update metrics pages to handle incomplete data

### DIFF
--- a/components/Metrics/ScientificContribution.vue
+++ b/components/Metrics/ScientificContribution.vue
@@ -81,7 +81,7 @@ export default {
                 'rgba(131, 0, 191, .5)',
               ],
               borderColor: 'rgba(131, 0, 191, .5)',
-              data: contribution.dataChartData.total
+              data: contribution.dataChartData?.total
             },
           ]
         },

--- a/components/Metrics/UserBehaviors.vue
+++ b/components/Metrics/UserBehaviors.vue
@@ -67,7 +67,7 @@ export default {
                 'rgba(131, 0, 191, .5)',
               ],
               borderColor: 'rgba(131, 0, 191, .5)',
-              data: behaviors.pageViewsData.lastMonth
+              data: behaviors.pageViewsData?.lastMonth
             },
             { 
               label: 'Last Quarter',
@@ -80,7 +80,7 @@ export default {
                 'rgba(188, 0, 252, .25)',
               ],
               borderColor: 'rgba(188, 0, 252, .25)',
-              data: behaviors.pageViewsData.last3Months
+              data: behaviors.pageViewsData?.last3Months
             }
           ]
         }
@@ -94,7 +94,7 @@ export default {
                 'rgba(131, 0, 191, .5)',
               ],
               borderColor: 'rgba(131, 0, 191, .5)',
-              data: behaviors.usersData.lastMonth
+              data: behaviors.usersData?.lastMonth
             },
             { 
               label: 'Last Quarter',
@@ -103,7 +103,7 @@ export default {
                 'rgba(188, 0, 252, .25)',
               ],
               borderColor: 'rgba(188, 0, 252, .25)',
-              data: behaviors.usersData.last3Months
+              data: behaviors.usersData?.last3Months
             }
           ]
         }

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -210,7 +210,7 @@ export default {
         subData: `(${metrics.downloadsLastMonth} last month)`
       }, {
         title: 'Dataset Contributors',
-        data: metrics.totalContributors.toString(),
+        data: metrics.totalContributors?.toString(),
         subData: `(${metrics.newContributors} new in the last month)`
       }]
     }))


### PR DESCRIPTION
Instead of breaking the app, we are now silently handling unpublished metrics data so that the app is still navigable. DAT is currently looking into why the metrics did not get published last month