### PR TITLE
Removed references to project section field

### DIFF
--- a/components/SearchResults/ProjectSearchResults.vue
+++ b/components/SearchResults/ProjectSearchResults.vue
@@ -27,11 +27,11 @@
         />
         <div class="mt-8 mb-8" v-html="highlightMatches(scope.row.fields.shortDescription, $route.query.search)"/>
         <table class="property-table">
-          <tr v-if="scope.row.fields.projectSection">
+          <tr v-if="scope.row.fields.focus">
             <td class="property-name-column">
               Focus
             </td>
-            <td v-html="highlightMatches(scope.row.fields.projectSection.fields.title, $route.query.search)"/>
+            <td v-html="highlightMatches(scope.row.fields.focus.join(), $route.query.search)"/>
           </tr>
           <tr v-if="scope.row.fields.principleInvestigator">
             <td class="property-name-column">

--- a/generate_sitemap.js
+++ b/generate_sitemap.js
@@ -105,8 +105,7 @@ process.stdout.write('Fetching projects from Contentful...')
 
 const projectResp = await contentfulClient.getEntries({
   content_type: 'sparcAward',
-  limit: 1000,
-  'fields.projectSection.sys.contentType.sys.id': 'awardSection'
+  limit: 1000
 })
 
 process.stdout.clearLine(0)

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -661,9 +661,7 @@ export default {
             limit: this.searchData.limit,
             skip: this.searchData.skip,
             order: sortOrder,
-            include: 2,
-            'fields.projectSection.sys.contentType.sys.id': linkedEntriesTargetType,
-            'fields.projectSection.fields.title[in]': anatomicalFocus,
+            'fields.focus[in]': anatomicalFocus,
             'fields.program[in]': funding
           })
           .then(async response => {

--- a/pages/projects/[projectId].vue
+++ b/pages/projects/[projectId].vue
@@ -14,12 +14,12 @@
             </div>
             <hr />
             <div class="body1">
-              <template v-if="projectSection">
+              <template v-if="focus">
                 <div class="label4">
                   FOCUS
                 </div>
                 <div class="mb-16">
-                  {{ projectSection }}
+                  {{ focus }}
                 </div>
               </template>
               <template v-if="investigator">
@@ -210,10 +210,8 @@ export default {
      * Compute subtitle based on its project section
      * @returns {String}
      */
-    projectSection: function() {
-      return this.fields.projectSection
-        ? this.fields?.projectSection.fields.title
-        : ''
+    focus: function() {
+      return propOr([], 'focus', this.fields).join(", ")
     },
     showAssociatedDatasets: function() {
       return !isEmpty(this.associatedDatasets)


### PR DESCRIPTION
In order to consolidate Content Types to make room for new ones I removed the project sections content type and instead created a 'focus' property on projects which is a list of strings instead of a list of references