### PR TITLE
Update error message when view gallery flatmap

### DIFF
--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -126,9 +126,6 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion, datasetFa
           flatmapData.push(speciesData)
         }
         scicrunchData['flatmaps'] = flatmapData
-      } else {
-        // Use the rat flatmap when no entity on the anatomical structure as generic flatmap
-        scicrunchData['flatmaps'] = [{ taxo: Uberons.species['rat'] }]
       }
     }
   } catch (e) {

--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -103,14 +103,14 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion, datasetFa
           }
         }
 
-        // Default species flatmap
+        // Generic species flatmap
         let speciesData = {
           taxo,
           id: datasetId,
           version: datasetVersion,
           species: species
         }
-        // Add uberonid and organ to the default flatmap if match the anatomy and taxonomy
+        // Add uberonid and organ to the generic flatmap if anatomy and taxonomy are matched
         scicrunchData.organs.forEach(organ => {
           if (foundAnatomy.includes(organ.curie)) {
             let organData = {
@@ -121,7 +121,8 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion, datasetFa
             flatmapData.push(organData)
           }
         })
-        // Use the default species flatmap when the anatomy and taxonomy not match
+        // Use the generic species flatmap when the anatomy and taxonomy not match
+        // No entity on the anatomical structure
         if (flatmapData.length === 0) {
           flatmapData.push(speciesData)
         }

--- a/pages/apps/maps/index.vue
+++ b/pages/apps/maps/index.vue
@@ -127,13 +127,15 @@ const checkSpecies = (route, organ, organ_name, taxo, for_species) => {
       route.query.for_species !== flatmaps.speciesMap[taxo]
     ) {
       failMessage = `Sorry! A flatmap for ${for_species} species does not yet exist. The ${organ_name} of a rat has been shown instead.`
+    } else if (!organ) {
+      failMessage = `Sorry! A entity on the anatomical structure does not yet exist. A generic flatmap for ${for_species} species has been shown instead.`
     }
   } else if (route.query.fid) {
     successMessage = "A flatmap's unique id is provided, a legacy map may be displayed instead."
   } else {
     failMessage = 'Sorry! Species information cannot be found. '
     if (organ) {
-      failMessage += `The ${organ} of a rat has been shown instead.`
+      failMessage += `The ${organ_name} of a rat has been shown instead.`
     } else {
       failMessage += 'A generic rat flatmap has been shown instead.'
     }

--- a/pages/apps/maps/index.vue
+++ b/pages/apps/maps/index.vue
@@ -128,7 +128,7 @@ const checkSpecies = (route, organ, organ_name, taxo, for_species) => {
     ) {
       failMessage = `Sorry! A flatmap for ${for_species} species does not yet exist. The ${organ_name} of a rat has been shown instead.`
     } else if (!organ) {
-      failMessage = `Sorry! A entity on the anatomical structure does not yet exist. A generic flatmap for ${for_species} species has been shown instead.`
+      failMessage = `Sorry! Applicable entity is not yet available. A generic flatmap for ${for_species} species has been shown instead.`
     }
   } else if (route.query.fid) {
     successMessage = "A flatmap's unique id is provided, a legacy map may be displayed instead."


### PR DESCRIPTION
As Yomi mentioned in [Display generic flatmap when there's no anatomical entity applicable for a dataset](https://www.wrike.com/open.htm?id=1280256873).

The following changes are used to add the `popup error messages` when no entity exists on the anatomical structure. 

<img width="767" alt="Screenshot 2024-05-24 at 10 06 25 AM" src="https://github.com/nih-sparc/sparc-app-2/assets/87633683/79454376-7b23-4234-b5b5-1be370f58e7b">
