### PR TITLE
Enable help mode dialog for maps.

### DIFF
--- a/components/MapViewer/MapViewer.client.vue
+++ b/components/MapViewer/MapViewer.client.vue
@@ -7,6 +7,7 @@
       :starting-map="startingMap"
       :options="options"
       :share-link="shareLink"
+      :useHelpModeDialog="true"
       @updateShareLinkRequested="$emit('updateShareLinkRequested')"
       @isReady="$emit('isReady')"
       @trackEvent="onTrackEvent"


### PR DESCRIPTION
This should be enabled before the QA/QC period starts.