### PR TITLE
Change event tracking method for maps to avoid data transformation

### DIFF
--- a/components/MapViewer/MapViewer.client.vue
+++ b/components/MapViewer/MapViewer.client.vue
@@ -59,7 +59,7 @@
         return this.$refs.map;
       },
       onTrackEvent: function(eventData) {
-        this.$gtm.trackEvent(eventData);
+        this.$gtm.push(eventData);
       },
     },
   }


### PR DESCRIPTION
Fix (not set) data in GA for Maps by replacing the tracking method because the `trackEvent` method transformed the data.