### PR TITLE
Remove action trigger event limit

### DIFF
--- a/.github/workflows/pull_request_cypress.yml
+++ b/.github/workflows/pull_request_cypress.yml
@@ -52,7 +52,6 @@ env:
 
 jobs:
   pull-request-cypress-run:
-    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/quality_control_cypress.yml
+++ b/.github/workflows/quality_control_cypress.yml
@@ -109,7 +109,6 @@ jobs:
           env: sparc-app-prod
 
   quality-control-cypress-run:
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/scheduled_production_cypress.yml
+++ b/.github/workflows/scheduled_production_cypress.yml
@@ -67,7 +67,6 @@ jobs:
           env: sparc-app-prod
 
   scheduled-cypress-run-production:
-    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/scheduled_staging_cypress.yml
+++ b/.github/workflows/scheduled_staging_cypress.yml
@@ -53,7 +53,6 @@ env:
 
 jobs:
   scheduled-cypress-run-staging:
-    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Should not be limited to only one event to run the action. e.g. scheduled testing sometimes may need a re-run