### PR TITLE
checkout-heroku-deployment

### DIFF
--- a/.github/workflows/quality_control_cypress.yml
+++ b/.github/workflows/quality_control_cypress.yml
@@ -98,11 +98,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      latest-sha: ${{ steps.latest-deployment-sha.outputs.sha }}
+      latest-sha: ${{ steps.latest-deployment-sha.outputs.deployment-sha }}
 
-    permissions:
-      deployments: read
-      contents: read
     steps:
       - name: Checkout
         id: checkout
@@ -110,17 +107,13 @@ jobs:
 
       - name: Get sha of latest deployment in main branch
         id: latest-deployment-sha
-        uses: vrnithinkumar/latest-deployment-sha@v1.0.0
+        uses: go-fjords/get-active-deployment-action@v0.0.3
         with:
-          repo_owner: nih-sparc
-          repo_name: sparc-app-2
           environment: sparc-app-prod
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Print latest deployment sha
         id: output
-        run: echo "${{ steps.latest-deployment-sha.outputs.sha }}"
+        run: echo "${{ steps.latest-deployment-sha.outputs.deployment-sha }}"
 
   quality-control-cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/scheduled_production_cypress.yml
+++ b/.github/workflows/scheduled_production_cypress.yml
@@ -56,11 +56,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      latest-sha: ${{ steps.latest-deployment-sha.outputs.sha }}
+      latest-sha: ${{ steps.latest-deployment-sha.outputs.deployment-sha }}
 
-    permissions:
-      deployments: read
-      contents: read
     steps:
       - name: Checkout
         id: checkout
@@ -68,17 +65,13 @@ jobs:
 
       - name: Get sha of latest deployment in main branch
         id: latest-deployment-sha
-        uses: vrnithinkumar/latest-deployment-sha@v1.0.0
+        uses: go-fjords/get-active-deployment-action@v0.0.3
         with:
-          repo_owner: nih-sparc
-          repo_name: sparc-app-2
           environment: sparc-app-prod
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Print latest deployment sha
         id: output
-        run: echo "${{ steps.latest-deployment-sha.outputs.sha }}"
+        run: echo "${{ steps.latest-deployment-sha.outputs.deployment-sha }}"
 
   scheduled-cypress-run-production:
     runs-on: ubuntu-latest

--- a/.github/workflows/scheduled_staging_cypress.yml
+++ b/.github/workflows/scheduled_staging_cypress.yml
@@ -56,11 +56,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      latest-sha: ${{ steps.latest-deployment-sha.outputs.sha }}
+      latest-sha: ${{ steps.latest-deployment-sha.outputs.deployment-sha }}
 
-    permissions:
-      deployments: read
-      contents: read
     steps:
       - name: Checkout
         id: checkout
@@ -68,17 +65,13 @@ jobs:
 
       - name: Get sha of latest deployment in main branch
         id: latest-deployment-sha
-        uses: vrnithinkumar/latest-deployment-sha@v1.0.0
+        uses: go-fjords/get-active-deployment-action@v0.0.3
         with:
-          repo_owner: nih-sparc
-          repo_name: sparc-app-2
           environment: sparc-app-2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Print latest deployment sha
         id: output
-        run: echo "${{ steps.latest-deployment-sha.outputs.sha }}"
+        run: echo "${{ steps.latest-deployment-sha.outputs.deployment-sha }}"
 
   scheduled-cypress-run-staging:
     runs-on: ubuntu-latest

--- a/tests/cypress/e2e/datasets.cy.js
+++ b/tests/cypress/e2e/datasets.cy.js
@@ -227,12 +227,13 @@ datasetIds.forEach(datasetId => {
           cy.get(':nth-child(11) > :nth-child(2) > a').invoke('attr', 'href').then((value) => {
             cy.get(':nth-child(8) > :nth-child(2) > a').should('have.attr', 'href', value);
           });
+          cy.wrap($content).get('.mt-8 > a > u').invoke('text').then((title) => {
+            cy.get('.dataset-about-info').contains(/Institution[(]s[)]: (.+)/i).children().not('.label4').invoke('text').then((institution) => {
+              cy.get('.mt-8 > a').click()
 
-          cy.get('.dataset-about-info').contains(/Institution[(]s[)]: (.+)/i).children().not('.label4').invoke('text').then((institution) => {
-            cy.get('.mt-8 > a').click()
-            cy.url({ timeout: 30000 }).should('contain', 'projects')
+              cy.waitForLoadingMask()
 
-            cy.wrap($content).get('.mt-8 > a > u').invoke('text').then((title) => {
+              cy.url().should('contain', 'projects')
               // Check for the title and the institution 
               cy.get('.row > .heading2').should('contain', title.trim());
               cy.get(':nth-child(4) > .label4').should('contain', institution.trim());


### PR DESCRIPTION
The current action not work for the Heroku deployment.

Passed jobs used the new action, the failed one used the current action.
<img width="396" alt="Screenshot 2024-06-21 at 10 05 31 AM" src="https://github.com/nih-sparc/sparc-app-2/assets/87633683/6aa97fb7-fbea-4fe4-9278-1d7fa0097c0e">

With the new action, the latest Heroku deployment commit sha is fetched based on deploy env.
<img width="929" alt="Screenshot 2024-06-21 at 10 16 23 AM" src="https://github.com/nih-sparc/sparc-app-2/assets/87633683/f8ccc96b-271c-4e9f-903b-f70c4bf28ed1">
<img width="997" alt="Screenshot 2024-06-21 at 10 15 48 AM" src="https://github.com/nih-sparc/sparc-app-2/assets/87633683/6a311630-2fc0-4546-98f7-ed7c8ef10945">
<img width="949" alt="Screenshot 2024-06-21 at 10 14 45 AM" src="https://github.com/nih-sparc/sparc-app-2/assets/87633683/f9a0269b-e909-48e6-a3dc-e73920b9b30b">
