### PR TITLE
Display biolucida images in gallery based on scicrunch

### DIFF
--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -517,13 +517,23 @@ export default {
       immediate: true,
       handler: function(biolucidaData) {
         const biolucida2DItems = pathOr([], ['dataset_info','biolucida-2d'], biolucidaData)
+        const biolucida3DItems = pathOr([], ['dataset_info','biolucida-3d'], biolucidaData)
         let items = []
         const baseRoute = this.$router.options.base || '/'
         if ('dataset_images' in biolucidaData) {
+          const validBiolucidaData = biolucidaData.dataset_images.filter(bObject => {
+            if (
+              biolucida2DItems.some(b2DItem => pathOr("", ['biolucida','identifier'], b2DItem) == bObject.image_id) ||
+              biolucida3DItems.some(b3DItem => pathOr("", ['biolucida','identifier'], b3DItem) == bObject.image_id)
+            ) {
+              return bObject
+            }
+          })
+          const uniqueBiolucidaData = validBiolucidaData.filter((bObject, index) => {
+            return index === validBiolucidaData.findIndex(bObject2 => bObject.image_id == bObject2.image_id);
+          })
           items.push(
-            ...Array.from(biolucidaData.dataset_images.filter((obj, index) => {
-              return index === biolucidaData.dataset_images.findIndex(o => obj.image_id === o.image_id);
-            }), dataset_image => {
+            ...Array.from(uniqueBiolucidaData, dataset_image => {
               let filePath = ""
               biolucida2DItems.forEach(biolucida2DItem => {
                 if (pathOr("", ['biolucida','identifier'], biolucida2DItem) == dataset_image.image_id) {

--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -522,15 +522,13 @@ export default {
         const baseRoute = this.$router.options.base || '/'
         if ('dataset_images' in biolucidaData) {
           const validBiolucidaData = biolucidaData.dataset_images.filter(bObject => {
-            if (
-              biolucida2DItems.some(b2DItem => pathOr("", ['biolucida','identifier'], b2DItem) == bObject.image_id) ||
-              biolucida3DItems.some(b3DItem => pathOr("", ['biolucida','identifier'], b3DItem) == bObject.image_id)
-            ) {
-              return bObject
-            }
+            return (
+              biolucida2DItems.some(b2DItem => pathOr("", ['biolucida', 'identifier'], b2DItem) == bObject.image_id) ||
+              biolucida3DItems.some(b3DItem => pathOr("", ['biolucida', 'identifier'], b3DItem) == bObject.image_id)
+            )
           })
           const uniqueBiolucidaData = validBiolucidaData.filter((bObject, index) => {
-            return index === validBiolucidaData.findIndex(bObject2 => bObject.image_id == bObject2.image_id);
+            return index == validBiolucidaData.findIndex(bObject2 => bObject.image_id == bObject2.image_id);
           })
           items.push(
             ...Array.from(uniqueBiolucidaData, dataset_image => {

--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -517,16 +517,15 @@ export default {
       immediate: true,
       handler: function(biolucidaData) {
         const biolucida2DItems = pathOr([], ['dataset_info','biolucida-2d'], biolucidaData)
-        const biolucida3DItems = pathOr([], ['dataset_info','biolucida-3d'], biolucidaData)
         let items = []
         const baseRoute = this.$router.options.base || '/'
         if ('dataset_images' in biolucidaData) {
+          // Images need to exist in both Scicrunch and Biolucida
           const validBiolucidaData = biolucidaData.dataset_images.filter(bObject => {
-            return (
-              biolucida2DItems.some(b2DItem => pathOr("", ['biolucida', 'identifier'], b2DItem) == bObject.image_id) ||
-              biolucida3DItems.some(b3DItem => pathOr("", ['biolucida', 'identifier'], b3DItem) == bObject.image_id)
-            )
+            const biolucidaItems = biolucida2DItems.concat(pathOr([], ['dataset_info','biolucida-3d'], biolucidaData))
+            return biolucidaItems.some(bItem => pathOr("", ['biolucida','identifier'], bItem) == bObject.image_id)
           })
+          // Duplicate images ids may exist
           const uniqueBiolucidaData = validBiolucidaData.filter((bObject, index) => {
             return index == validBiolucidaData.findIndex(bObject2 => bObject.image_id == bObject2.image_id);
           })


### PR DESCRIPTION
For sprint ticket - [Bug Submission: Image viewer not opening](https://www.wrike.com/open.htm?id=1363738055)

This should help to hide the biolucida image whose id does not exist in Scicrunch.