### PR TITLE
Add help link for viewers

### DIFF
--- a/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
+++ b/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
@@ -7,6 +7,11 @@
         <form ref="zipForm" method="POST" :action="zipitUrl">
           <input v-model="zipData" type="hidden" name="data" />
         </form>  
+        <span class="help-link" v-if="hasViewer && (activeTabId in helpers)">
+          <a :href="`https://docs.sparc.science/docs/${helpers[activeTabId].link}`" target="_blank">
+            Find out more about the {{ helpers[activeTabId].name }}
+          </a>
+        </span>
         <content-tab-card v-if="hasViewer" class="mt-24" :tabs="tabs" :active-tab-id="activeTabId">
           <biolucida-viewer v-if="hasBiolucidaViewer" v-show="activeTabId === 'imageViewer'" :data="biolucidaData"
             :datasetInfo="datasetInfo" :file="file" />
@@ -225,7 +230,21 @@ export default {
       tabs: [],
       file: {},
       zipData: '',
-      zipitUrl: config.public.zipit_api_host
+      zipitUrl: config.public.zipit_api_host,
+      helpers: {
+        imageViewer: {
+          name: 'Biolucida Viewer',
+          link: 'image-viewer-overview'
+        },
+        segmentationViewer: {
+          name: 'Segmentation Viewer',
+          link: 'segmentation-viewer-overview'
+        },
+        plotViewer: {
+          name: 'Plot Viewer',
+          link: 'plot-viewer'
+        }
+      }
     }
   },
 
@@ -368,3 +387,12 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.help-link {
+  float: right;
+  @media screen and (max-width: 29rem) {
+    float: none;
+  }
+}
+</style>

--- a/tests/cypress/e2e/homepage.cy.js
+++ b/tests/cypress/e2e/homepage.cy.js
@@ -67,8 +67,8 @@ describe('Homepage', { testIsolation: false }, function () {
 
     // Check for button link
     cy.get(':nth-child(1) > .feature-container > .button-link').should('contain', 'Data and Models').and('have.attr', 'href', '/data?type=dataset')
-    cy.get(':nth-child(2) > .feature-container > .button-link').should('contain', 'Maps').and('have.attr', 'href', '/maps')
-    cy.get(':nth-child(3) > .feature-container > .button-link').should('contain', 'Discover').and('have.attr', 'href').and('contain', '/resources')
+    cy.get(':nth-child(2) > .feature-container > .button-link').should('contain', 'Maps').and('have.attr', 'href', '/apps/maps?type=ac')
+    cy.get(':nth-child(3) > .feature-container > .button-link').should('contain', 'Discover').and('have.attr', 'href').and('contain', '/tools-and-resources')
     cy.get(':nth-child(4) > .feature-container > .button-link').should('contain', 'Submit').and('have.attr', 'href', '/share-data')
   })
 


### PR DESCRIPTION
This PR is for the sprint 39 ticket - [Defining Bespoke Biolucida Viewer tool](https://www.wrike.com/open.htm?id=1410285490).


As required, added the link - `Find out more about the ...` to the Biolucida tool page on the image viewer. It will open the [image viewer docs](https://docs.sparc.science/docs/image-viewer-overview) page.

<img width="400" alt="Screenshot 2024-08-02 at 12 05 24 PM" src="https://github.com/user-attachments/assets/2e1276bd-d2e4-42e1-ac67-e2cf697ab6f1">
<img width="200" alt="Screenshot 2024-08-02 at 12 05 57 PM" src="https://github.com/user-attachments/assets/beda6306-b7cc-45fe-b8b8-93bf8a7c8359">


Extra: Although not sure whether it is needed. The help link has been added to the segmentation and plot viewer as well.

<img width="400" alt="Screenshot 2024-08-02 at 12 41 08 PM" src="https://github.com/user-attachments/assets/70362ebc-9b91-4f8e-b9b1-af1e2bfc6b95">
