### PR TITLE
Add blvlink request

### DIFF
--- a/components/BiolucidaViewer/BiolucidaViewer.vue
+++ b/components/BiolucidaViewer/BiolucidaViewer.vue
@@ -95,17 +95,21 @@ export default {
         ''
       )
       const [
+        blv_info,
         view_info,
         image_info,
       ] = await Promise.all([
+        biolucida.getBLVLink(image_identifier),
         biolucida.decodeViewParameter(viewId),
         biolucida.getImageInfo(image_identifier),
       ])
+      const blv_link = props.data.blv_link ? props.data.blv_link : blv_info['link']
       const BASE_URL = `blv:${config.public.BL_SERVER_URL}`
       const queryParameters = `image_id=${image_identifier}&type=${view_info[1]}${view_info[2]}&filename=${image_info.name}`
       const webNeurolucidaLink = BASE_URL + '/image_view?' + queryParameters
 
       return {
+        blv_link,
         webNeurolucidaLink
       }
     } catch (e) {
@@ -120,7 +124,7 @@ export default {
   },
   methods: {
     launchViewer() {
-      window.open(this.data.blv_link, '_blank')
+      window.open(this.blv_link, '_blank')
     },
     launchNL360C() {
       biolucida

--- a/components/ViewersMetadata/BiolucidaViewerMetadata.vue
+++ b/components/ViewersMetadata/BiolucidaViewerMetadata.vue
@@ -120,11 +120,9 @@ export default {
     try {
       const image_identifier = props.biolucidaData.biolucida_image_id
       const [
-        blv_info,
         xmp_metadata,
         readme_markdown
       ] = await Promise.all([
-        biolucida.getBLVLink(image_identifier),
         biolucida.getXMPInfo(image_identifier),
         fetch(props.datasetInfo.readme).then((response) => {
           return response.text()
@@ -133,10 +131,8 @@ export default {
 
       const html = MarkedMixin.methods.parseMarkdown(readme_markdown)
       const data_collection = extractSection(/data collect[^:]+:/i, html)
-      const blv_link = blv_info['link']
       return {
         data_collection,
-        blv_link,
         xmp_metadata
       }
     } catch (e) {


### PR DESCRIPTION
This PR is for the wrike ticket - [3D Button across Image Viewers not Behaving as Expected](https://www.wrike.com/open.htm?id=1383898088)

The blv link does not exist in the response from the `imagemap/sharelink` endpoint request. 

It may be because the response structure has changed sometime in the past or has never had the BLV link. Moved the blv link request from the ViewerMetadata component to the Viewer component.

It will now show the following page after clicking the button.

<img width="1512" alt="Screenshot 2024-08-06 at 9 38 24 AM" src="https://github.com/user-attachments/assets/098c93be-b06e-4336-a5a9-9d01ac5af1e8">

