### PR TITLE
Fix issue when invalid route query used in map page

### DIFF
--- a/pages/apps/maps/index.vue
+++ b/pages/apps/maps/index.vue
@@ -302,6 +302,7 @@ const openViewWithQuery = async (router, route, $axios, sparcApi, algoliaIndex, 
     startingMap = "WholeBody"
   } else {
     router.replace({ ...router.currentRoute, query: { type: 'ac' } })
+    failMessage = 'Invalid parameters were detected. Default parameters will now be used.'
   }
 
   return [startingMap, organ_name, currentEntry, successMessage, failMessage, facets]

--- a/pages/apps/maps/index.vue
+++ b/pages/apps/maps/index.vue
@@ -259,7 +259,7 @@ const restoreStateWithUUID = async (route, $axios, sparcApi) => {
   return [uuid, state, successMessage, failMessage]
 }
 
-const openViewWithQuery = async (route, $axios, sparcApi, algoliaIndex, discover_api, $pennsieveApiClient) => {
+const openViewWithQuery = async (router, route, $axios, sparcApi, algoliaIndex, discover_api, $pennsieveApiClient) => {
   //Open the map with specific view defined by the query.
   //First get the bucket and facets information if available
   let s3Bucket = undefined
@@ -300,6 +300,8 @@ const openViewWithQuery = async (route, $axios, sparcApi, algoliaIndex, discover
     return await processEntry(route)
   } else if (route.query.type === 'wholebody') {
     startingMap = "WholeBody"
+  } else {
+    router.replace({ ...router.currentRoute, query: { type: 'ac' } })
   }
 
   return [startingMap, organ_name, currentEntry, successMessage, failMessage, facets]
@@ -310,6 +312,7 @@ export default {
   async setup() {
     const config = useRuntimeConfig()
     const { $algoliaClient, $axios, $pennsieveApiClient } = useNuxtApp()
+    const router = useRouter()
     const route = useRoute()
     let startingMap = "AC"
     let organ_name = undefined
@@ -347,7 +350,7 @@ export default {
         successMessage,
         failMessage,
         facets
-      ] = await openViewWithQuery(route, $axios, options.sparcApi, algoliaIndex,
+      ] = await openViewWithQuery(router, route, $axios, options.sparcApi, algoliaIndex,
         config.public.discover_api_host, $pennsieveApiClient)
     }
 


### PR DESCRIPTION
The route query - `type` is now only checking whether is matching with valid data. When randon type is used, mapvuer will show `AC` by default but url will remain the wrong type.

Replaced the url query type to `ac`.