### PR TITLE
UI fix for map popover arrow

### DIFF
--- a/components/MapViewer/MapViewer.client.vue
+++ b/components/MapViewer/MapViewer.client.vue
@@ -82,8 +82,13 @@
   }
 
   .background-popper.el-popover.el-popper,
-  .open-map-popper.el-popover.el-popper {
+  .open-map-popper.el-popover.el-popper,
+  .context-card-popover.el-popover.el-popper {
     background: #fff !important;
+
+    .el-popper__arrow::before {
+      background-color: #fff !important;
+    }
   }
 
   .open-map-popper.el-popover.el-popper {

--- a/components/MapViewer/MapViewer.client.vue
+++ b/components/MapViewer/MapViewer.client.vue
@@ -91,6 +91,13 @@
     }
   }
 
+  .context-card-popover {
+    .flatmap-context-card,
+    .context-card-container.context-card {
+      border-radius: 4px;
+    }
+  }
+
   .open-map-popper.el-popover.el-popper {
     width: unset !important;
   }


### PR DESCRIPTION
This fix is for the UI of the following popovers on the map.

1. The context card popover border-radius and arrow colour.

![image](https://github.com/user-attachments/assets/d8e9a65a-7201-44ec-9ac7-b06c5c5f24c8)

2. The settings and open-map popover arrow colour.
 
![image](https://github.com/user-attachments/assets/70489969-c89b-4811-9745-0f02eddb0ee7)
