### PR TITLE
Add inner try-catch to catch biolucida request issue separately

### DIFF
--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -54,9 +54,17 @@ const getThumbnailData = async (datasetDoi, datasetId, datasetVersion, datasetFa
     await scicrunch.getDatasetInfoFromDOI(datasetDoi).then(response => {
       scicrunch_response = response
     })
-    await biolucida.searchDataset(datasetId).then(response => {
-      biolucida_response = response
-    })
+    // Inner try-catch for biolucida request errors
+    try {
+      await biolucida.searchDataset(datasetId).then(response => {
+        biolucida_response = response
+      })
+    } catch (error) {
+      console.error(
+        'Hit error in the biolucida request. ( pages/_datasetId.vue ). Error: ',
+        error
+      )
+    }
 
     if (scicrunch_response.data.result.length > 0) {
       scicrunchData = scicrunch_response.data.result[0]


### PR DESCRIPTION
This is to fix the image gallery testing issue caused by failed biolucida requests. 

Previously, one `try-catch` was used for both scrunch and biolucida requests. If one fails, another one will be affected. This is causing no items in the gallery.
<img width="600" alt="Screenshot 2024-08-27 at 9 56 55 AM" src="https://github.com/user-attachments/assets/3f6797cc-a214-4e87-be12-3d3248560f4d">

Added the inner `try-catch` for biolucida request. Scicrunch-based functionality will not be affected (e.g. dataset info/UI display) if the biolucida request failed.
<img width="600" alt="Screenshot 2024-08-27 at 9 57 48 AM" src="https://github.com/user-attachments/assets/e854593b-747b-4983-aa21-7e2fb86b3044">

Gallery testing will not be affected by the biolucida server issue as long as the scicrunch server works fine.