### PR TITLE
updated portal notification id and fixed homepage news nuxt error

### DIFF
--- a/components/HomepageNews/HomepageNews.vue
+++ b/components/HomepageNews/HomepageNews.vue
@@ -95,7 +95,7 @@ import { pathOr } from 'ramda'
 import SparcCard from '@/components/SparcCard/SparcCard.vue'
 import MarkedMixin from '@/mixins/marked'
 import FormatDate from '@/mixins/format-date'
-import { isInternalLink } from '@/mixins/marked/index'
+import { isAnchor } from '@/mixins/marked/index'
 export default {
   name: 'HomepageNews',
   components: {
@@ -129,7 +129,7 @@ export default {
     }
   },
   methods: {
-    isInternalLink,
+    isAnchor,
     async fetchBitlyLinks() {
       this.upcomingNews.forEach(async item => {
         const url = pathOr("", ['fields', 'url'], item)
@@ -143,16 +143,21 @@ export default {
               }
             })
             const newUrl = response.data.long_url
-            this.itemIsInternalLink.push(isInternalLink(newUrl))
+            this.itemIsInternalLink.push(this.isInternalLink(newUrl))
           } catch {
             console.log("Error retreiving bitly link destination url")
-            this.itemIsInternalLink.push(isInternalLink(url))
+            this.itemIsInternalLink.push(this.isInternalLink(url))
           }
         }
         else {
-          this.itemIsInternalLink.push(isInternalLink(url))
+          this.itemIsInternalLink.push(this.isInternalLink(url))
         }
       })
+    },
+    isInternalLink(str){
+      return isAnchor(str)
+        ? true
+        : str.includes(this.$config.public.ROOT_URL) || str.includes("sparc.science") || str.startsWith('/')
     },
     /**
      * Get image source

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -116,7 +116,7 @@ export default defineNuxtConfig({
       CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,
       CTF_API_HOST: process.env.CTF_API_HOST || 'preview.contentful.com',
       ctf_home_page_id: '4qJ9WUWXg09FAUvCnbGxBY',
-      ctf_portal_notification_entry_id: 'XiVlrkTXeKxTyN1Q2oY2Q',
+      ctf_portal_notification_entry_id: '5S8eazBlD1Y47pTO1EQfQ3',
       ctf_contact_us_form_options_id: '79rwRA0rUqUj6rc913BFsz',
       ctf_project_id: 'sparcAward',
       ctf_about_page_id: '4VOSvJtgtFv1PS2lklMcnS',


### PR DESCRIPTION
Updated portal notification entry id after Dominic deleted the old one

Attempting to fix this new error that is appearing on prod: 

Error retreiving bitly link destination url
2024-09-07T16:43:48.645946+00:00 app[web.1]: [nitro] [unhandledRejection] Error: [nuxt] instance unavailable
2024-09-07T16:43:48.645947+00:00 app[web.1]:     at useNuxtApp (file:///app/.output/server/chunks/app/server.mjs:316:13)
2024-09-07T16:43:48.645949+00:00 app[web.1]:     at useRuntimeConfig (file:///app/.output/server/chunks/app/server.mjs:323:27)
2024-09-07T16:43:48.645949+00:00 app[web.1]:     at isInternalLink (file:///app/.output/server/chunks/app/_nuxt/index-KTohXJYK.mjs:31:18)
2024-09-07T16:43:48.645949+00:00 app[web.1]:     at file:///app/.output/server/chunks/app/_nuxt/index-P0Rdvtnj.mjs:273:42
2024-09-07T16:43:48.645950+00:00 app[web.1]:     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Nuxt 3 does not like the useRuntimeConfig() being called outside of setup