### PR TITLE
Add missing organization name in fallback

### DIFF
--- a/pages/datasets/[datasetId].vue
+++ b/pages/datasets/[datasetId].vue
@@ -69,7 +69,7 @@
       </div>
       <dataset-version-message v-if="!isLatestVersion" :current-version="datasetInfo.version"
         :dataset-details="datasetInfo" />
-    
+
   </div>
 </template>
 
@@ -101,7 +101,7 @@ const getDatasetDetails = async (config, datasetId, version, $axios, $pennsieveA
   const url = `${config.public.portal_api}/sim/dataset/${datasetId}`
   var datasetUrl = version ? `${url}/versions/${version}` : url
 
-  const datasetDetails = await $axios.get(datasetUrl).catch(async (error) => { 
+  const datasetDetails = await $axios.get(datasetUrl).catch(async (error) => {
     const status = propOr('', 'status', error.response)
     // If not found, then try accessing it directly from Pennsieve in case it has been unpublished
     if (status == 404) {
@@ -162,7 +162,8 @@ const getOrganizationNames = async (algoliaIndex) => {
       'SPARC Consortium',
       'RE-JOIN',
       'HEAL PRECISION',
-      "IT'IS Foundation"
+      "IT'IS Foundation",
+      'NIH PRECISION Human Pain Network',
     ]
   }
 }


### PR DESCRIPTION
The dataset 407 has the new organization name, `"organizationName": "NIH PRECISION Human Pain Network"`, and it is not in the `pennsieve.organization.name` list, and also not in the fallback values list of `getOrganizationNames`.
When the dataset's organization name is not in the list of `sparcOrganizationNames`, it is trying to redirect to DOI link. 
https://github.com/nih-sparc/sparc-app-2/blob/0b391050103b669ef325328aa2326fae2be9ce95/pages/datasets/%5BdatasetId%5D.vue#L292
However, when the DOI link is redirected back to the dataset page, it ends up in an endless loop and throws a 500 error.

This fix is to prevent that error by adding the missing organization name in the fallback.
