### PR TITLE
Fix missing segmentation viewer metadata

### DIFF
--- a/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
+++ b/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
@@ -160,6 +160,11 @@ export default {
       if (packageType == 'Unsupported') {
         await discover.getSegmentationInfo(route.params.datasetId, filePath, s3Bucket).then(({ data }) => {
           segmentationData = data
+          // file is from pennsieve, filePath is from scicrunch
+          // Normally filePath will be correct if path in file and filePath not the same
+          if (file.path != filePath) {
+            file.path = filePath
+          }
         })
       }
     } catch(e) {


### PR DESCRIPTION
This PR is to fix the ticket issue - [Missing Thumbnail and Metadata on Segmentation Viewer](https://www.wrike.com/open.htm?id=1465344178). 

The issue is due to the incorrect file path used to fetch the metadata. 

This file path used to fetch viewer metadata is from Pennsieve, which may differ from the one from Scicrunch. The file path in Scicrunch will usually be the correct one. Therefore, replace the path in the file with the Scicrunch file path.

Segmentations in dataset 230:

<img width="300" alt="Screenshot 2024-09-16 at 9 31 58 AM" src="https://github.com/user-attachments/assets/c3cb51bf-3331-48a9-83fe-64a13c636dd5">

<img width="300" alt="Screenshot 2024-09-16 at 9 31 28 AM" src="https://github.com/user-attachments/assets/5d3ef40e-699a-4048-9bf5-816d4d05a0d9">
