### PR TITLE
Remove duplicate biolucida image

### DIFF
--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -537,13 +537,17 @@ export default {
         this.scicrunchItems = items
 
         if ('dataset_images' in scicrunchData && ('biolucida-2d' in scicrunchData || 'biolucida-3d' in scicrunchData)) {
-          const biolucida2DItems = pathOr([],['biolucida-2d'], scicrunchData)
+          const biolucida2DItems = pathOr([], ['biolucida-2d'], scicrunchData)
           // Images need to exist in both Scicrunch and Biolucida
-          const biolucidaItems = biolucida2DItems.concat(pathOr([],['biolucida-3d'], scicrunchData)).filter((bObject) => {
-            return scicrunchData['dataset_images'].some(image => image.image_id == pathOr("", ['biolucida','identifier'], bObject))
+          let biolucidaItems = {}
+          biolucida2DItems.concat(pathOr([], ['biolucida-3d'], scicrunchData)).forEach((bObject) => {
+            const biolucidaId = pathOr("", ['biolucida','identifier'], bObject)
+            if (biolucidaId && scicrunchData['dataset_images'].some(image => image.image_id == biolucidaId)) {
+              biolucidaItems[biolucidaId] = bObject
+            }
           })
           bItems.push(
-            ...Array.from(biolucidaItems, biolucida_item => {
+            ...Array.from(Object.values(biolucidaItems), biolucida_item => {
               let filePath = ""
               const dataset_image = scicrunchData['dataset_images'].find((image) => {
                 return image.image_id == pathOr("", ['biolucida','identifier'], biolucida_item)


### PR DESCRIPTION
This is to fix the ticket issue - [Missing Thumbnail for Dataset 381 and 230](https://www.wrike.com/open.htm?id=1465389934)

This issue is similar to the one we solved earlier, PR - [Sync gallery fixes](https://github.com/nih-sparc/sparc-app-2/pull/70/files). Duplicated image data exists in the related image API response.
The above fix is removed after an image gallery code refactoring, PR - [Display biolucida images in gallery based on scicrunch](https://github.com/nih-sparc/sparc-app-2/pull/152). However, duplicate image data still exists in Scicrunch.

Add remove duplicate image data code back.

For images in dataset 381:
<img width="400" alt="Screenshot 2024-09-16 at 9 41 16 AM" src="https://github.com/user-attachments/assets/c8026995-6a89-4b7b-a004-9592f46fdca9">

<img width="400" alt="Screenshot 2024-09-16 at 9 40 26 AM" src="https://github.com/user-attachments/assets/a1c36649-fa17-4788-a7ba-5f26cd89a112">
