### PR TITLE
add NIH to list of viewable orgs for datasets

### DIFF
--- a/pages/datasets/[datasetId].vue
+++ b/pages/datasets/[datasetId].vue
@@ -162,7 +162,8 @@ const getOrganizationNames = async (algoliaIndex) => {
       'SPARC Consortium',
       'RE-JOIN',
       'HEAL PRECISION',
-      "IT'IS Foundation"
+      "IT'IS Foundation",
+      "NIH PRECISION Human Pain Network"
     ]
   }
 }


### PR DESCRIPTION
Hot Fix: NIH specific dataset was erroring with 500. Fix was to add "NIH PRECISION Human Pain Network" to list of organizations allowed to be viewed as a dataset in SPARC. 
