### PR TITLE
Portal notification now uses the same el-message as other pages.

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,6 +15,7 @@ import { propOr } from 'ramda'
 import DOMPurify from 'isomorphic-dompurify'
 import { useMainStore } from '../store/index.js'
 import { mapState } from 'pinia'
+import { customMessage } from '@/utils/notification-messages'
 
 export default {
   components: {
@@ -54,7 +55,7 @@ export default {
           if (!displayOnHomePageOnly || (displayOnHomePageOnly && currentlyOnHomePage)) {
             switch (messageType) {
               case 'Error': {
-                this.$message({
+                customMessage({
                   message: message,
                   showClose: true,
                   iconClass: 'el-icon-circle-close',
@@ -65,7 +66,7 @@ export default {
                 break
               }
               case 'Success': {
-                this.$message({
+                customMessage({
                   message: message,
                   showClose: true,
                   iconClass: 'el-icon-circle-check',
@@ -76,7 +77,7 @@ export default {
                 break
               }
               case 'Information': {
-                this.$message({
+                customMessage({
                   message: message,
                   showClose: true,
                   iconClass: 'about-icon',

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@abi-software/mapintegratedvuer": "1.5.1",
     "@abi-software/plotvuer": "1.0.3",
     "@abi-software/simulationvuer": "1.0.1",
-    "@element-plus/nuxt": "^1.0.6",
+    "@element-plus/nuxt": "^1.0.10",
     "@nuxtjs/sitemap": "^5.1.4",
     "@pinia-plugin-persistedstate/nuxt": "^1.2.0",
     "@pinia/nuxt": "^0.5.1",

--- a/utils/notification-messages.js
+++ b/utils/notification-messages.js
@@ -42,7 +42,7 @@ export const infoMessage = message => {
 
 /**
  * Custom notification message object
- * @param {Object} Object containing all message required
+ * @param {Object} Object containing required data for ElMessage
  * @return {Object}
  */
 export const customMessage = data => {

--- a/utils/notification-messages.js
+++ b/utils/notification-messages.js
@@ -3,7 +3,6 @@
  * @param {String} message
  * @return {Object}
  */
-
 export const successMessage = message => {
   ElMessage({
     showClose: true,
@@ -12,6 +11,7 @@ export const successMessage = message => {
     duration: 5000
   })
 }
+
 /**
  * Failure notification message object
  * @param {String} message
@@ -38,4 +38,13 @@ export const infoMessage = message => {
     type: 'info',
     duration: 5000
   })
+}
+
+/**
+ * Custom notification message object
+ * @param {Object} Object containing all message required
+ * @return {Object}
+ */
+export const customMessage = data => {
+  ElMessage(data)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3443,14 +3443,14 @@
   resolved "https://registry.npmjs.org/@element-plus/icons-vue/-/icons-vue-2.3.1.tgz"
   integrity sha512-XxVUZv48RZAd87ucGS48jPf6pKu0yV5UCg9f4FFwtrYxXOwWuVJo6wOvSLKEoMQKjv8GsX/mhP6UsC1lRwbUWg==
 
-"@element-plus/nuxt@^1.0.6":
-  version "1.0.7"
-  resolved "https://registry.npmjs.org/@element-plus/nuxt/-/nuxt-1.0.7.tgz"
-  integrity sha512-cRP2iMTzrKKKgfXuWXQ/HAC1vawVeErNZPz7ylA2OfhR+RKPS0UbDy43zytBx/imxhuZbtDI6lPuGAf7TOMYDQ==
+"@element-plus/nuxt@^1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@element-plus/nuxt/-/nuxt-1.0.10.tgz#c1c8fa917bedae728934976ccd82cc15293fdadb"
+  integrity sha512-jz8kWXr0cBc/9fN2fWdoiTVFWGVzltobZ0FIIEyG0AoXsNl2BJr7urvvscJS3UFy+zjVuFxB4FULLpx9RcwQLA==
   dependencies:
-    "@nuxt/kit" "^3.7.1"
+    "@nuxt/kit" "^3.12.3"
     magic-string "^0.27.0"
-    unplugin "^1.0.1"
+    unplugin "^1.11.0"
 
 "@esbuild/aix-ppc64@0.19.12":
   version "0.19.12"
@@ -4893,7 +4893,7 @@
     which "^3.0.1"
     ws "^8.16.0"
 
-"@nuxt/kit@3.10.1", "@nuxt/kit@^3.4.0", "@nuxt/kit@^3.5.0", "@nuxt/kit@^3.5.1", "@nuxt/kit@^3.7.1", "@nuxt/kit@^3.8.0", "@nuxt/kit@^3.8.2":
+"@nuxt/kit@3.10.1", "@nuxt/kit@^3.4.0", "@nuxt/kit@^3.5.0", "@nuxt/kit@^3.5.1", "@nuxt/kit@^3.8.0", "@nuxt/kit@^3.8.2":
   version "3.10.1"
   resolved "https://registry.npmjs.org/@nuxt/kit/-/kit-3.10.1.tgz"
   integrity sha512-M9VRY0QGbG6lWOVqt69ZF96RLBUZVXyFpbBUwHnoHgjF9BXSX/MT/hrZcJicN4aPM2QRephGgsBd4U5wFmmn6g==
@@ -4967,9 +4967,9 @@
     unimport "^3.7.2"
     untyped "^1.4.2"
 
-"@nuxt/kit@^3.11.2":
+"@nuxt/kit@^3.11.2", "@nuxt/kit@^3.12.3":
   version "3.13.2"
-  resolved "https://registry.npmjs.org/@nuxt/kit/-/kit-3.13.2.tgz"
+  resolved "https://registry.yarnpkg.com/@nuxt/kit/-/kit-3.13.2.tgz#4c019a87e08c33ec14d1059497ba40568b82bfed"
   integrity sha512-KvRw21zU//wdz25IeE1E5m/aFSzhJloBRAQtv+evcFeZvuroIxpIQuUqhbzuwznaUwpiWbmwlcsp5uOWmi4vwA==
   dependencies:
     "@nuxt/schema" "3.13.2"
@@ -17881,7 +17881,7 @@ unplugin-vue-router@^0.7.0:
     unplugin "^1.5.0"
     yaml "^2.3.2"
 
-unplugin@^1.0.1, unplugin@^1.10.1, unplugin@^1.14.1, unplugin@^1.3.1, unplugin@^1.4.0, unplugin@^1.5.0, unplugin@^1.6.0:
+unplugin@^1.10.1, unplugin@^1.11.0, unplugin@^1.14.1, unplugin@^1.3.1, unplugin@^1.4.0, unplugin@^1.5.0, unplugin@^1.6.0:
   version "1.14.1"
   resolved "https://registry.npmjs.org/unplugin/-/unplugin-1.14.1.tgz"
   integrity sha512-lBlHbfSFPToDYp9pjXlUEFVxYLaue9f9T1HC+4OHlmj+HnMDdz9oZY+erXfoCe/5V/7gKUSY2jpXPb9S7f0f/w==


### PR DESCRIPTION
Portal notification now uses the same element message system as the rest of the portal. This addresses an issue with overlapping messages.

Before:
![image](https://github.com/user-attachments/assets/b37ec415-6910-4abe-a648-fdffd07ed5c5)
After:
![image](https://github.com/user-attachments/assets/03ab6c17-947c-4866-abee-d3202805b814)

I have also noticed an issue with element-plux/nuxt reported [here](https://github.com/element-plus/element-plus-nuxt/pull/91).
Updating the element-plus/nuxt package has fixed it.