### PR TITLE
metadata file location navigation

### DIFF
--- a/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
+++ b/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
@@ -156,10 +156,12 @@ export default {
       if (packageType == 'Unsupported') {
         await discover.getSegmentationInfo(route.params.datasetId, filePath, s3Bucket).then(({ data }) => {
           segmentationData = data
-          // file is from pennsieve, filePath is from scicrunch
-          // Normally filePath will be correct if path in file and filePath not the same
+          // file is from Pennsieve, filePath is from Scicrunch
           if (file.path != filePath) {
+            // Normally filePath will be correct if file.path and filePath not the same
             file.path = filePath
+            // Need to update the file.name as well if file.path is changed
+            file.name = filePath.substring(filePath.lastIndexOf('/') + 1)
           }
         })
       }


### PR DESCRIPTION
This is to fix a further issue after the commit [b7bca4af4f037631b7af457997d0476a3ed43b94](https://github.com/nih-sparc/sparc-app-2/commit/b7bca4af4f037631b7af457997d0476a3ed43b94).

The file name in Pennsieve does not match the name in the path stored in Scicrunch. Therefore, the file location navigation does not work as expected.

Click the file location in the following two links to see the difference (dataset 230 segmentation viewer).

- [staging](https://staging.sparc.science/datasets/file/230/2?path=files/primary/sub-dorsal-1/sam-CGRP-Mouse-Dorsal-1/3D_scaffold_-_CGRP-Mice-Dorsal-1.xml)

- [local](http://localhost:3000/datasets/file/230/2?path=files/primary/sub-dorsal-1/sam-CGRP-Mouse-Dorsal-1/3D_scaffold_-_CGRP-Mice-Dorsal-1.xml)