### PR TITLE
Removed reference to tools and events page contentful entry

### DIFF
--- a/components/OsparcServices/OsparcServices.vue
+++ b/components/OsparcServices/OsparcServices.vue
@@ -49,15 +49,13 @@
 import { ref } from 'vue'
 import SearchControlsContentful from '@/components/SearchControlsContentful/SearchControlsContentful.vue'
 import ServicesSearchResults from '@/components/Resources/ServicesSearchResults.vue'
-import SubmitToolSection from '@/components/Resources/SubmitToolSection.vue'
 
 export default {
   name: 'OsparcServices',
 
   components: {
     SearchControlsContentful,
-    ServicesSearchResults,
-    SubmitToolSection
+    ServicesSearchResults
   },
 
   async setup() {

--- a/components/Resources/SubmitToolSection.vue
+++ b/components/Resources/SubmitToolSection.vue
@@ -1,35 +1,35 @@
 <template>
-  <paper
-    :text="parseMarkdown(searchPaperText)"
-    :button-text="searchPaperButton"
-    :button-link="{ name: 'contact-us', query: { type: 'tool'} }"
-    new-tab
-  />
+  <div class="subpage">
+    <div class="heading2 mb-12">
+      Submit a Tool or Resource
+    </div>
+    <div class="mb-12">
+      Our goal is to collect useful Tools and Resources to share with the Community to enable researchers to access and enhance the current datasets and knowledge they can gain from the SPARC Portal for their own research.
+    </div>
+    <a
+      :href="`/contact-us?type=tool`"
+      target="_blank"
+    >
+      <el-button class="secondary">
+        Submit Tool <svgo-icon-open class="icon-open" />
+      </el-button>
+    </a>
+  </div>
 </template>
 
 <script>
-import Paper from '@/components/Paper/Paper.vue'
-import marked from '@/mixins/marked/index'
-
 export default {
-  name: 'SubmitToolSection',
-
-  mixins: [marked],
-
-  components: {
-    Paper
-  },
-
-  async setup() {
-    const { $contentfulClient } = useNuxtApp()
-    const config = useRuntimeConfig()
-    const response = await $contentfulClient.getEntry(config.public.ctf_tools_and_resources_page_id)
-    const searchPaperButton = response.fields.searchPaperButton
-    const searchPaperText = response.fields.searchPaperText
-    return {
-      searchPaperText,
-      searchPaperButton
-    }
-  }
+  name: 'SubmitToolSection'
 }
 </script>
+<style lang="scss" scoped>
+.subpage {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 1rem;
+}
+.icon-open {
+  height: 1rem;
+  width: 1rem;
+}
+</style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -130,7 +130,6 @@ export default defineNuxtConfig({
       ctf_share_data_page_id: '5w2F52873w6g9TH4YMVxXW',
       ctf_team_and_leadership_page_id: '7EL9Plxo7q2GyCzg1sqIcg',
       ctf_get_involved_page_id: 'jxEBoBw2zUctuDaX2eeX1',
-      ctf_tools_and_resources_page_id: '1Yy2BEB0df8HxLNx2Ivsct',
       ctf_osparc_resource_entry_id: '4LkLiH5s4FV0LVJd3htsvH',
       ctf_contact_us_form_type_id: 'contactUsForm',
       ctf_apps_page_id: '4LyfrYarHrt8Fke5ufyjdy',


### PR DESCRIPTION
Refactored submit tool section in order to remove a content type from Contentful which was initially there to populate the tools and resources home page from before we had tabs