### PR TITLE
Bugfix for Broken Dataset Page

### DIFF
--- a/pages/datasets/[datasetId].vue
+++ b/pages/datasets/[datasetId].vue
@@ -249,7 +249,10 @@ export default {
         getOrganizationIds(algoliaIndex),
         getContributorsFromAlgolia(algoliaIndex, datasetId)
       ])
-      const datasetDetailsContributors = algoliaContributors?.map(contributor => {
+      const filteredAlgoliaContributors = algoliaContributors.filter(contributor =>
+        contributor.first || contributor.last
+      )
+      const datasetDetailsContributors = filteredAlgoliaContributors?.map(contributor => {
         return {
           firstName: contributor.first?.name,
           lastName: contributor.last?.name,
@@ -269,7 +272,7 @@ export default {
           name: propOr('', 'organizationName', datasetDetails)
         }
       ]
-      const contributors = algoliaContributors?.map(contributor => {
+      const contributors = filteredAlgoliaContributors?.map(contributor => {
         const sameAs = contributor.curie
           ? `http://orcid.org/${contributor.curie.replace('ORCID:', '')}`
           : null

--- a/pages/datasets/[datasetId].vue
+++ b/pages/datasets/[datasetId].vue
@@ -251,8 +251,8 @@ export default {
       ])
       const datasetDetailsContributors = algoliaContributors?.map(contributor => {
         return {
-          firstName: contributor.first.name,
-          lastName: contributor.last.name,
+          firstName: contributor.first?.name,
+          lastName: contributor.last?.name,
           orcid: contributor.curie?.replace('ORCID:', '')
         }
       })


### PR DESCRIPTION
This PR addresses a 500 server error on the dataset page for dataset 43. 
The issue is caused by missing contributor names in the contributors' list. The fix involves removing contributors who do not have a name.