### PR TITLE
Remove workflow timeout

### DIFF
--- a/.github/workflows/pull_request_cypress.yml
+++ b/.github/workflows/pull_request_cypress.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Automated Run Testing when Pull Request
         if: steps.checkUser.outputs.require-result == 'true'
         uses: cypress-io/github-action@v6
-        timeout-minutes: 30
         env:
           ROOT_URL: ${{ secrets.ROOT_URL }} # http://localhost:3000
         with:

--- a/.github/workflows/quality_control_cypress.yml
+++ b/.github/workflows/quality_control_cypress.yml
@@ -142,7 +142,6 @@ jobs:
         env:
           ROOT_URL: "https://sparc.science"
         uses: cypress-io/github-action@v6
-        timeout-minutes: 30
         with:
           wait-on: ${{ env.ROOT_URL }}
           record: true

--- a/.github/workflows/scheduled_production_cypress.yml
+++ b/.github/workflows/scheduled_production_cypress.yml
@@ -98,7 +98,6 @@ jobs:
 
       - name: Schedule Run Testing against Production
         uses: cypress-io/github-action@v6
-        timeout-minutes: 30
         env:
           ROOT_URL: "https://sparc.science"
         with:

--- a/.github/workflows/scheduled_staging_cypress.yml
+++ b/.github/workflows/scheduled_staging_cypress.yml
@@ -98,7 +98,6 @@ jobs:
 
       - name: Schedule Run Testing against Staging
         uses: cypress-io/github-action@v6
-        timeout-minutes: 30
         env:
           ROOT_URL: "https://staging.sparc.science"
         with:


### PR DESCRIPTION
This is to make sure the testing for the PR - [Testing improvement](https://github.com/nih-sparc/sparc-app-2/pull/228) will not abort because of timeout.