### PR TITLE
allow google bot to index site content

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -238,6 +238,6 @@ export default defineNuxtConfig({
       '/news-and-events/community-spotlight/submit'
     ] : ['/'],
     blockNonSeoBots: true,
-    crawlDelay: 3600
+    crawlDelay: 300
   }
 })

--- a/server/middleware/webCrawlers.js
+++ b/server/middleware/webCrawlers.js
@@ -23,10 +23,6 @@ export default defineEventHandler((event) => {
     if (userAgent && botNames.some(botName => userAgent.indexOf(botName.toLowerCase()) !== -1)) {
       res.statusCode = 403
       res.end('Bot detected, serving 403 response.')
-    } else if (userAgent && (userAgent.includes('googlebot') || userAgent.includes("google.com/bot.html"))) {
-      res.statusCode = 200
-      res.setHeader('Content-Type', 'text/plain')
-      res.end('Googlebot detected, serving empty response.')
     }
   }
 })


### PR DESCRIPTION
don't return empty response to googlebot, and decrease the crawl delay. Google was ignoring indexing since it thought there was no content on the site