### PR TITLE
Prevent googlebot from recursively indexing

### DIFF
--- a/components/Footer/FooterLink.vue
+++ b/components/Footer/FooterLink.vue
@@ -31,7 +31,10 @@ export default {
 
   computed: {
     currentUrl() {
-      return encodeURIComponent(this.$route.fullPath)
+      const config = useRuntimeConfig()
+      const url = new URL(this.$route.fullPath, config.public.ROOT_URL)
+      url.searchParams.delete('source_url') // Remove existing source_url in order to prevent indexing recursion
+      return encodeURIComponent(url.pathname + url.search)
     },
     isFeedbackLink() {
       const title = this.link.fields.title

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -235,7 +235,8 @@ export default defineNuxtConfig({
       '/signup', 
       '/maps',
       '/news-and-events/submit',
-      '/news-and-events/community-spotlight/submit'
+      '/news-and-events/community-spotlight/submit',
+      '/*?source_url='
     ] : ['/'],
     blockNonSeoBots: true,
     crawlDelay: 300

--- a/pages/contact-us/index.vue
+++ b/pages/contact-us/index.vue
@@ -6,6 +6,8 @@
     <Meta name="description" hid="description" :content="breadcrumbTitle" />
     <Meta name="og:description" hid="og:description" :content="breadcrumbTitle" />
     <Meta name="twitter:description" :content="breadcrumbTitle" />
+    <link rel="canonical" href="https://sparc.science/contact-us" />
+    <Meta name="robots" content="noindex, nofollow" />
   </Head>
   <div class="contact-us-page pb-16">
     <breadcrumb :breadcrumb="breadcrumb" :title="breadcrumbTitle" />

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -6,6 +6,7 @@
     <Meta name="description" hid="description" :content="`Browse ${title}`" />
     <Meta name="og:description" hid="og:description" :content="`Browse ${title}`" />
     <Meta name="twitter:description" :content="`Browse ${title}`" />
+    <link rel="canonical" href="https://sparc.science/data" />
     <Meta name="robots" content="noindex, nofollow" />
   </Head>
   <div class="page-data">


### PR DESCRIPTION
After allowing indexing for googlebot, it was recursively indexing the contact-us page due to the footer link always appending a source_url param instead of first stripping the old one from the url. This was causing a constant recursive indexing resulting in very high api usage and constant Papertrail logs.