### PR TITLE
allow indexing of dataset id pages

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -227,6 +227,7 @@ export default defineNuxtConfig({
     // disallowing certain pages that are either redirects, authticated routes, or causing bots to recursively crawl
     disallow: process.env.DEPLOY_ENV === 'production' ? 
     [
+      '/datasets/',
       '/datasets/*?*',
       '/welcome', 
       '/user', 

--- a/pages/datasets/[datasetId].vue
+++ b/pages/datasets/[datasetId].vue
@@ -22,7 +22,6 @@
     <Meta name="DC.publisher" content="Pennsieve Discover" />
     <Meta name="DC.date" :content="originallyPublishedDate" scheme="DCTERMS.W3CDTF" />
     <Meta name="DC.version" :content="datasetInfo?.version.toString()" />
-    <Meta name="robots" content="noindex, nofollow" />
   </Head>
   <div class="dataset-details pb-16">
 


### PR DESCRIPTION
Missed allowing dataset id pages to get indexed when submitting this PR: https://github.com/nih-sparc/sparc-app-2/pull/247 

Since the dataset id urls are specified in the sitemap.xml then googlebot will still be allowed to index just those instead of trying to index every different number