### PR TITLE
Update crosscite

### DIFF
--- a/components/CitationDetails/CitationDetails.vue
+++ b/components/CitationDetails/CitationDetails.vue
@@ -60,9 +60,9 @@
         <span class="label4">Internal Server Error</span><br />
         Sorry, something went wrong.<br />
         The dataset citation generator (<a
-          href="https://citation.crosscite.org/"
+          :href="crosscite_host"
           target="_blank"
-        >https://citation.crosscite.org/</a>) encountered an internal error and was unable to complete your
+        >{{crosscite_host}}</a>) encountered an internal error and was unable to complete your
         request.<br />
         Please come back later.
       </div>
@@ -70,10 +70,10 @@
     <p style="text-align: end">
       More citations available at:
       <a
-        :href="`https://citation.crosscite.org/?doi=${doiValue}`"
+        :href="crosscite_host"
         target="_blank"
       >
-        Crosscite.org
+        DOI Citation Formatter
       </a>
     </p>
   </div>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -163,7 +163,7 @@ export default defineNuxtConfig({
       SHOW_DATASET_SUBMISSION_FEATURE: process.env.SHOW_DATASET_SUBMISSION_FEATURE || 'false',
       METACELL_SDS_VIEWER_URL: process.env.METACELL_SDS_VIEWER_URL || 'https://metacell.github.io/sds-viewer',
       ORCID_API_URL: process.env.ORCID_API_URL || 'https://pub.orcid.org/v2.1',
-      crosscite_api_host: process.env.CROSSCITE_API_HOST || 'https://citation.crosscite.org',
+      crosscite_api_host: process.env.CROSSCITE_API_HOST || 'https://citation.doi.org',
       max_download_size: parseInt(process.env.MAX_DOWNLOAD_SIZE || '5000000000'),
       osparc_host: process.env.OSPARC_HOST || 'https://osparc.io',
       MBF_SPARC_API: process.env.MBF_SPARC_API || 'https://mbfsparcapi.com',

--- a/tests/cypress/e2e/datasets/detailtabs.cy.js
+++ b/tests/cypress/e2e/datasets/detailtabs.cy.js
@@ -304,7 +304,7 @@ datasetIds.forEach((datasetId) => {
           cy.get('.citation-details > p > a').then(($link) => {
             expect($link, 'Link should open a new tab').to.have.attr('target').to.contain('blank')
             cy.wrap($link).invoke('attr', 'href').then((href) => {
-              expect(href, 'Link should have correct href').to.contain(`https://citation.doi.org/?doi=${doi}`)
+              expect(href, 'Link should have correct href').to.contain(`https://citation.doi.org`)
               cy.request(href).then((resp) => {
                 expect(resp.status).to.eq(200)
               })

--- a/tests/cypress/e2e/datasets/detailtabs.cy.js
+++ b/tests/cypress/e2e/datasets/detailtabs.cy.js
@@ -304,7 +304,7 @@ datasetIds.forEach((datasetId) => {
           cy.get('.citation-details > p > a').then(($link) => {
             expect($link, 'Link should open a new tab').to.have.attr('target').to.contain('blank')
             cy.wrap($link).invoke('attr', 'href').then((href) => {
-              expect(href, 'Link should have correct href').to.contain(`https://citation.crosscite.org/?doi=${doi}`)
+              expect(href, 'Link should have correct href').to.contain(`https://citation.doi.org/?doi=${doi}`)
               cy.request(href).then((resp) => {
                 expect(resp.status).to.eq(200)
               })


### PR DESCRIPTION
https://citation.crosscite.org/ is now replaced by https://citation.doi.org/, this pull request will update the default value of the environment variable and remove some of the hardcoded parts.

I have deployed the update here - https://alan-wu-sparc-app.herokuapp.com/
By the way, link in the following format https://citation.crosscite.org/?doi=${doi} is not available with https://citation.doi.org yet.