### PR TITLE
Put a timeout on the publication reference tab between each APA citat…

### DIFF
--- a/components/DatasetDetails/DatasetReferences.vue
+++ b/components/DatasetDetails/DatasetReferences.vue
@@ -65,6 +65,7 @@ export default {
       const current = display.length
       if (total > current) {
         display.push(original[current])
+        if (original.length === display.length) return
         setTimeout(() => {
           this.addPublicationsForDisplay(original, display)
         }, 500);

--- a/components/DatasetDetails/DatasetReferences.vue
+++ b/components/DatasetDetails/DatasetReferences.vue
@@ -68,7 +68,7 @@ export default {
         if (original.length === display.length) return
         setTimeout(() => {
           this.addPublicationsForDisplay(original, display)
-        }, 600);
+        }, 1000);
       }
     },
     updatePrimaryPublicationsDisplay: function() {

--- a/components/DatasetDetails/DatasetReferences.vue
+++ b/components/DatasetDetails/DatasetReferences.vue
@@ -69,7 +69,7 @@ export default {
           if (original.length === display.length) return
           setTimeout(() => {
             this.addPublicationsForDisplay(original, display)
-          }, 1000);
+          }, 1000)
         }
       }
     },
@@ -113,8 +113,14 @@ export default {
     }
   },
   mounted: function() {
-    this.updatePrimaryPublicationsDisplay()
-    this.updateAssociatedPublicationsDisplay()
+    //Add a timeout at the beginnering as well as there is a chance
+    //other part of the dataset page are accessing api from the same domain
+    setTimeout(() => {
+      this.updatePrimaryPublicationsDisplay()
+    }, 500)
+    setTimeout(() => {
+      this.updateAssociatedPublicationsDisplay()
+    }, 1000)
   }
 }
 </script>

--- a/components/DatasetDetails/DatasetReferences.vue
+++ b/components/DatasetDetails/DatasetReferences.vue
@@ -61,14 +61,16 @@ export default {
   },
   methods: {
     addPublicationsForDisplay: function(original, display) {
-      const total = original.length
-      const current = display.length
-      if (total > current) {
-        display.push(original[current])
-        if (original.length === display.length) return
-        setTimeout(() => {
-          this.addPublicationsForDisplay(original, display)
-        }, 1000);
+      if (original) {
+        const total = original.length
+        const current = display.length
+        if (total > current) {
+          display.push(original[current])
+          if (original.length === display.length) return
+          setTimeout(() => {
+            this.addPublicationsForDisplay(original, display)
+          }, 1000);
+        }
       }
     },
     updatePrimaryPublicationsDisplay: function() {

--- a/components/DatasetDetails/DatasetReferences.vue
+++ b/components/DatasetDetails/DatasetReferences.vue
@@ -4,7 +4,7 @@
       <div class="heading2 mb-8">
         Primary Publications for this Dataset
       </div>
-      <div v-for="(item, index) in primaryPublications" :key="index">
+      <div v-for="(item, index) in primaryPublicationsDisplay" :key="index">
         <apa-citation @doi-invalid="onDoiInvalid" class="mb-8" :doi="item.doi" />
       </div>
       <hr v-if="associatedPublications" />
@@ -13,7 +13,7 @@
       <div class="heading2 mb-8">
         Associated Publications for this Dataset
       </div>
-      <div v-for="(item, index) in associatedPublications" :key="index">
+      <div v-for="(item, index) in associatedPublicationsDisplay" :key="index">
         <apa-citation @doi-invalid="onDoiInvalid" class="mb-8" :doi="item.doi" />
       </div>
       <hr v-if="preprints" />
@@ -53,6 +53,48 @@ export default {
       default: () => []
     },
   },
+  data() {
+    return {
+      primaryPublicationsDisplay: [],
+      associatedPublicationsDisplay: [],
+    }
+  },
+  methods: {
+    addPublicationsForDisplay: function(original, display) {
+      const total = original.length
+      const current = display.length
+      if (total > current) {
+        display.push(original[current])
+        setTimeout(() => {
+          this.addPublicationsForDisplay(original, display)
+        }, 500);
+      }
+    },
+    updatePrimaryPublicationsDisplay: function() {
+      this.primaryPublicationsDisplay.length = 0
+      this.addPublicationsForDisplay(this.primaryPublications,
+        this.primaryPublicationsDisplay)
+    },
+    updateAssociatedPublicationsDisplay: function() {
+      this.associatedPublicationsDisplay.length = 0
+      this.addPublicationsForDisplay(this.associatedPublications,
+        this.associatedPublicationsDisplay)
+    },
+  },
+  watch: {
+    primaryPublications: {
+      handler: function () {
+        this.updatePrimaryPublicationsDisplay()
+      },
+      immediate: false
+    },
+    associatedPublications: {
+      handler: function () {
+        this.updateAssociatedPublicationsDisplay()
+      },
+      immediate: false
+    },
+  },
   computed: {
     preprints: function() {
       let preprintPublications = []
@@ -66,6 +108,10 @@ export default {
       })
       return isEmpty(preprintPublications) ? undefined : preprintPublications
     }
+  },
+  mounted: function() {
+    this.updatePrimaryPublicationsDisplay()
+    this.updateAssociatedPublicationsDisplay()
   }
 }
 </script>

--- a/components/DatasetDetails/DatasetReferences.vue
+++ b/components/DatasetDetails/DatasetReferences.vue
@@ -68,7 +68,7 @@ export default {
         if (original.length === display.length) return
         setTimeout(() => {
           this.addPublicationsForDisplay(original, display)
-        }, 500);
+        }, 600);
       }
     },
     updatePrimaryPublicationsDisplay: function() {


### PR DESCRIPTION
Add a timeout when populating the APA citation in the references tab to avoid hitting the rate limit with the crossref api.

The issue can be observed occasionally with Firefox here - https://sparc.science/datasets/236?type=dataset&datasetDetailsTab=references

I have deployed it here for testing - https://alan-wu-sparc-app.herokuapp.com/datasets/236?type=dataset&datasetDetailsTab=references