### PR TITLE
Biolucida sharelink

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "date-fns": "^2.30.0",
     "gridstack": "^10.1.2",
     "isomorphic-dompurify": "^1.9.0",
+    "js-base64": "^3.7.7",
     "js-file-download": "^0.4.12",
     "lodash": "^4.17.21",
     "marked": "^8.0.1",

--- a/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
+++ b/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
@@ -39,7 +39,6 @@
 
 <script>
 import discover from '@/services/discover'
-import biolucida from '@/services/biolucida'
 import scicrunch from '@/services/scicrunch'
 import BiolucidaViewer from '@/components/BiolucidaViewer/BiolucidaViewer'
 import SegmentationViewer from '@/components/SegmentationViewer/SegmentationViewer'
@@ -160,6 +159,9 @@ export default {
     if (matchedBioData?.length) {
       const image_id = pathOr('', ['biolucida', 'identifier'], matchedBioData[0])
       biolucidaData.biolucida_image_id = image_id
+      // The encoded string is in the following format -
+      // ${image_id}-col-${collection_id}, collection id can be any valid collection id
+      // and 260 is used for now.
       const code = encodeURIComponent(Base64.encode(`${image_id}-col-260`))
       biolucidaData.share_link = `${config.public.BL_SHARE_LINK_PREFIX}${code}`
       biolucidaData.status = "Successful"

--- a/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
+++ b/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
@@ -54,6 +54,7 @@ import Gallery from '@/components/Gallery/Gallery.vue'
 import { extractS3BucketName } from '@/utils/common'
 
 import { isEmpty, pathOr, propOr } from 'ramda'
+import { Base64  } from 'js-base64'
 
 export default {
   name: 'DatasetFileDetailPage',
@@ -107,42 +108,14 @@ export default {
       }
     }
 
-    // We should just be able to do as below and pull the source package id from file, but there are sometimes discrepancies between the pennsieve file sourcePackageId and the biolucida image data sourcePackageId returned from sparc.biolucida.net
-    // const sourcePackageId = file.sourcePackageId
-    // So now we must pull all the images from the dataset, then get each ones dataset info (to use the file name to map it) so that we can get the source package id from the right image 
     let sourcePackageId = ""
-    let biolucidaData = {}
-    try {
-      const biolucidaSearchResults = await biolucida.searchDataset(route.params.datasetId)
-      //sort the following with reverse order, make sure the latest images get prioritised
-      let imagesData = biolucidaSearchResults['dataset_images']
-      imagesData = imagesData.reverse()
-      if (packageType == 'Image' && imagesData != undefined) {
-        await Promise.all(imagesData.map(async image => {
-          const imageInfo = await biolucida.getImageInfo(image.image_id)
-          if (imageInfo['name'] == file.name)
-          {
-            sourcePackageId = image['sourcepkg_id']
-            biolucidaData.biolucida_image_id = image.image_id
-            biolucidaData.share_link = image.share_link
-            biolucidaData.status = imageInfo.status
-            biolucidaData.type_field = image.type_field
-            return
-          }
-        }))
-      }
-    } catch (e) {
-      console.log(`Error retrieving biolucida data (possibly because there is none for this file): ${e}`)
-    }
-
-    const hasBiolucidaViewer = !isEmpty(biolucidaData) && biolucidaData.status !== 'error'
-
     // We must remove the N: in order for scicrunch to realize the package
     sourcePackageId = file.sourcePackageId
     const expectedScicrunchIdentifier = sourcePackageId != undefined ? sourcePackageId.replace("N:", "") : ""
     let scicrunchData = {}
     try {
-      if (packageType == 'Others' && expectedScicrunchIdentifier != "") {
+      if ((packageType == 'Others' || packageType == 'Image') &&
+        expectedScicrunchIdentifier != "") {
         const scicrunchResponse = await scicrunch.getDatasetInfoFromObjectIdentifier(expectedScicrunchIdentifier)
         const result = pathOr([], ['data', 'result'], scicrunchResponse)
         scicrunchData = result?.length > 0 ? result[0] : []
@@ -174,6 +147,24 @@ export default {
       console.log(`Error retrieving segmentation data (possibly because there is none for this file): ${e}`)
     }
     const hasSegmentationViewer = !isEmpty(segmentationData)
+
+    let biolucidaData = {}
+    let matchedBioData = scicrunchData['biolucida-2d']?.filter(function(el) {
+      return el.identifier == expectedScicrunchIdentifier
+    })
+    if (!matchedBioData?.length) {
+      matchedBioData = scicrunchData['biolucida-3d']?.filter(function(el) {
+        return el.identifier == expectedScicrunchIdentifier
+      })
+    }
+    if (matchedBioData?.length) {
+      const image_id = pathOr('', ['biolucida', 'identifier'], matchedBioData[0])
+      biolucidaData.biolucida_image_id = image_id
+      const code = encodeURIComponent(Base64.encode(`${image_id}-col-260`))
+      biolucidaData.share_link = `${config.public.BL_SHARE_LINK_PREFIX}${code}`
+      biolucidaData.status = "Successful"
+    }
+    const hasBiolucidaViewer = !isEmpty(biolucidaData) && biolucidaData.status !== 'error'
     
     let plotData = {}
     const matchedPlotData = scicrunchData['abi-plot']?.filter(function(el) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12974,6 +12974,11 @@ jiti@^1.21.6:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.6.tgz#6c7f7398dd4b3142767f9a168af2f317a428d268"
   integrity sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==
 
+js-base64@^3.7.7:
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
+  integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
+
 js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"


### PR DESCRIPTION
Use information from SciCrunch instead of Biolucida to create the sharelink. This will make the availability of images consistent with the image gallery. This feature can be tested here - https://alan-wu-sparc-app.herokuapp.com/