### PR TITLE
Fix a copy error on Biolucida page.

### DIFF
--- a/components/BiolucidaViewer/BiolucidaViewer.vue
+++ b/components/BiolucidaViewer/BiolucidaViewer.vue
@@ -174,7 +174,7 @@ export default {
           } else {
             linkPath += `&location=${message}`
           }
-          this.$copyText(linkPath).then(
+          navigator.clipboard.writeText(linkPath).then(
             () => {
               successMessage('Share link copied to clipboard.')
             },


### PR DESCRIPTION
Replace this.$copyText with navigator.clipboard.writeText.

Unfortunately this cannot be tested as the biolucida endpoint will only talk to the staging and production site.