### PR TITLE
made default type param undefined

### DIFF
--- a/components/SearchResults/DatasetSearchResults.vue
+++ b/components/SearchResults/DatasetSearchResults.vue
@@ -188,8 +188,8 @@ export default {
       return item !== undefined ? 
         (item.types[0].name === 'computational model' ? 'simulation'
           : item.types[0].name === 'device' ? 'device'
-          : 'dataset') :
-        ''
+          : undefined) :
+        undefined
     }
   }
 }


### PR DESCRIPTION
In order to fix page 'flashing' back to datasets tab before navigating to dataset details page I made the links type param default to  undefined instead of dataset as this was causing the tab to switch unnecessarily before navigation which was the reason for this ticket: https://www.wrike.com/open.htm?id=1589011381