### PR TITLE
Hide files tab for code repos

### DIFF
--- a/pages/datasets/[datasetId].vue
+++ b/pages/datasets/[datasetId].vue
@@ -448,7 +448,8 @@ export default {
       return pathOr('', ['params', 'datasetId'], this.$route)
     },
     hasFiles: function () {
-      return this.fileCount >= 1
+      // do not show the files tab for code repos
+      return this.fileCount >= 1 && !this.hasSourceCode
     },
     fileCount: function () {
       return propOr('0', 'fileCount', this.datasetInfo)


### PR DESCRIPTION
As recommended by Dominic, hiding the files tab for code repo datasets so that users have to navigate to github to download files