### PR TITLE
Scaffold context card testing minor update

### DIFF
--- a/tests/cypress/e2e/datasets/imagegallery.cy.js
+++ b/tests/cypress/e2e/datasets/imagegallery.cy.js
@@ -110,6 +110,8 @@ datasetIds.forEach((datasetId) => {
                         cy.get('.pane-1 > .content-container > .toolbar > .toolbar-flex-container > .el-select > .el-select__wrapper > .el-select__selection > .el-select__placeholder > span').should(($title) => {
                           expect($title, 'Map Viewer should display scaffold').to.contain('Scaffold')
                         })
+                        cy.waitForScaffoldLoading()
+                        cy.checkScaffoldContextCard()
                       }
                       if (item === 'Flatmap') {
                         cy.get('.toolbar-title').should(($title) => {

--- a/tests/cypress/e2e/mapsviewer.cy.js
+++ b/tests/cypress/e2e/mapsviewer.cy.js
@@ -416,18 +416,7 @@ mapTypes.forEach((map) => {
                 cy.waitForScaffoldLoading()
                 cy.waitForMapTreeControlLoading()
                 // Check for context card
-                cy.get('.context-card').should(($card) => {
-                  expect($card, 'The context card should be displayed').to.be.visible
-                })
-                cy.get('.context-image').should(($image) => {
-                  expect($image, 'The context card should have an image').to.exist
-                })
-                cy.get('.card-right > :nth-child(1) > .title').should(($title) => {
-                  expect($title, 'The context card should have a title class').to.have.class('title')
-                })
-                cy.get('.card-right > :nth-child(1) > :nth-child(2) > :nth-child(1)').should(($description) => {
-                  expect($description, 'The context card should have a description').to.exist
-                })
+                cy.checkScaffoldContextCard()
               }
             })
           })

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -307,3 +307,21 @@ Cypress.Commands.add('clickOnNeuron', (coordinate, pixel) => {
   }
   clickOnNeuron()
 })
+
+Cypress.Commands.add('checkScaffoldContextCard', () => {
+  cy.get('.context-card').should(($card) => {
+    expect($card, 'The context card should be displayed').to.be.visible
+  })
+  cy.get('.context-image').should(($image) => {
+    expect($image, 'Context image should be loaded').to.have.prop('naturalWidth').to.be.greaterThan(0)
+  })
+  cy.get('.view-image').should(($image) => {
+    expect($image, 'View image should be loaded').to.have.prop('naturalWidth').to.be.greaterThan(0)
+  })
+  cy.get('.card-right > :nth-child(1) > .title').should(($title) => {
+    expect($title, 'The context card should have a title class').to.have.class('title')
+  })
+  cy.get('.card-right > :nth-child(1) > :nth-child(2) > :nth-child(1)').should(($description) => {
+    expect($description, 'The context card should have a description').to.exist
+  })
+})


### PR DESCRIPTION
Currently, e2e testing cannot correctly detect whether the scaffold context card image is loaded.

The changes should be able to detect the image issue.

Failure example:
<img width="836" alt="Screenshot 2025-02-21 at 3 57 11 PM" src="https://github.com/user-attachments/assets/ade9933a-b12f-4253-bd22-2ad59219bd01" />
