### PR TITLE
added ability to hide consortias

### DIFF
--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -96,6 +96,7 @@ const { data: consortiaItems, error: consortiaError } = useAsyncData('consortiaI
     const { items } = await $contentfulClient.getEntries({
       content_type: config.public.ctf_consortia_content_type_id,
       order: 'fields.displayOrder',
+      'fields.displayOnAboutPage': true
     })
     return items
   } catch (err) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -116,6 +116,7 @@ const { data: consortiaItems, error: consortiaError } = useAsyncData('consortiaI
     const { items } = await $contentfulClient.getEntries({
       content_type: config.public.ctf_consortia_content_type_id,
       order: 'fields.displayOrder',
+      'fields.displayOnHomepage': true,
     })
     return items
   } catch (err) {


### PR DESCRIPTION
As requested by Sue, added the ability to create consortias without them being shown on the homepage and/or about page