### PR TITLE
E2e about metadata

### DIFF
--- a/tests/cypress/e2e/datasets/detailtabs.cy.js
+++ b/tests/cypress/e2e/datasets/detailtabs.cy.js
@@ -257,20 +257,22 @@ datasetIds.forEach((datasetId) => {
             const projects = $project.text().replace('Associated project(s):', '').split(',').map((project) => project.trim())
             cy.get('@institutions').then(($institution) => {
               const institutions = $institution.text().replace('Institution(s):', '').split(',').map((institution) => institution.trim())
-              cy.get('.dataset-about-info .label4').contains(/Associated project[(]s[)]/i).parent().find('a').each(($link, index) => {
-                cy.get('.dataset-about-info .label4').contains(/Associated project[(]s[)]/i).parent().find('a').eq(index).click()
-                cy.waitForPageLoading()
-                cy.get('.row > .heading2', { timeout: 60000 }).should(($title) => {
-                  expect($title, 'Project title should be the same').to.contain(projects[index])
+              if (!projects.includes('None specified') && !institutions.includes('None specified')) {
+                cy.get('.dataset-about-info .label4').contains(/Associated project[(]s[)]/i).parent().find('a').each(($link, index) => {
+                  cy.get('.dataset-about-info .label4').contains(/Associated project[(]s[)]/i).parent().find('a').eq(index).click()
+                  cy.waitForPageLoading()
+                  cy.get('.row > .heading2', { timeout: 60000 }).should(($title) => {
+                    expect($title, 'Project title should be the same').to.contain(projects[index])
+                  })
+                  cy.get('span.label4').parent().contains(/INSTITUTION[(]S[)]/i).should(($institution) => {
+                    expect($institution, 'Institution should be the same').to.contain(institutions[index])
+                  })
+                  cy.get('.link1').should(($award) => {
+                    expect(awards[index], 'Award should be the same').to.include($award.text().trim())
+                  })
+                  cy.backToDetailPage(datasetId)
                 })
-                cy.get('span.label4').parent().contains(/INSTITUTION[(]S[)]/i).should(($institution) => {
-                  expect($institution, 'Institution should be the same').to.contain(institutions[index])
-                })
-                cy.get('.link1').should(($award) => {
-                  expect(awards[index], 'Award should be the same').to.include($award.text().trim())
-                })
-                cy.backToDetailPage(datasetId)
-              })
+              }
             })
           })
         })

--- a/tests/cypress/e2e/datasets/detailtabs.cy.js
+++ b/tests/cypress/e2e/datasets/detailtabs.cy.js
@@ -180,11 +180,15 @@ datasetIds.forEach((datasetId) => {
           expect($content.text().trim(), '"Contact Author" content should exist').to.match(/Contact Author:(.+)/is)
         })
         cy.get('.dataset-about-info .label4').contains(/Award[(]s[)]/i).parent().as('awards')
-        cy.get('@awards').should(($content) => {
+        cy.get('@awards').then(($content) => {
           expect($content.text().trim(), '"Awards" content should exist').to.match(/Award[(]s[)]:(.+)/is)
-        })
-        cy.get('@awards').find('a').should(($award) => {
-          expect($award, 'Award href should exist').to.have.attr('href').to.contain('/about/projects/')
+          cy.wrap($content).children().not('.label4').each(($award) => {
+            if ($award[0].children.length) { // Has children, has link 
+              cy.wrap($award).find('a').should(($link) => {
+                expect($link, 'Award href should exist').to.have.attr('href').to.contain('/about/projects/')
+              })
+            }
+          })
         })
         cy.get('.dataset-about-info .label4').contains(/Funding Program[(]s[)]/i).parent().should(($content) => {
           expect($content.text().trim(), '"Funding Programs" content should exist').to.match(/Funding Program[(]s[)]:(.+)/is)


### PR DESCRIPTION
<img width="200" alt="Screenshot 2025-03-11 at 11 54 43 AM" src="https://github.com/user-attachments/assets/a22e518b-73a7-434e-b0ef-e3f678c4286f" />
<img width="200" alt="Screenshot 2025-03-11 at 11 54 20 AM" src="https://github.com/user-attachments/assets/79d4a17d-007a-4216-a4bc-9b506d905493" />

> 224- About tab (associated project) is picking up error for the  none specified metadata (This has been worked on in the last sprint to have award number as none specified for datasets that do not have that info. Please can the test be modified to not pick this as an error but rather focus on blank metadata)

Based on the review comment, the above two test failures should not be picked. Update to skip further tests when conditions are not satisfied.