### PR TITLE
Updated facet ids to be labels instead of dynamically generated ids

### DIFF
--- a/utils/algolia.ts
+++ b/utils/algolia.ts
@@ -56,7 +56,7 @@ export const facetPropPathMapping = [
 export const getAlgoliaFacets = function(algoliaIndex : SearchIndex, propPathMapping : Array<{id: string, facetPropPath: string, facetSubpropPath: string, label: string}>, filters : string) {
   const facetPropPaths = propPathMapping.map(item => item.facetPropPath)
   const facetSubpropPaths = propPathMapping.map(item => item.facetSubpropPath)
-  var facetData: { label: String, id: number, children: object[], key: string }[] = []
+  var facetData: { label: string, id: string, children: object[], key: string }[] = []
   var facetId = 0
   return algoliaIndex
     .search('', {
@@ -68,7 +68,7 @@ export const getAlgoliaFacets = function(algoliaIndex : SearchIndex, propPathMap
     .then(response => {
       facetPropPaths.map((facetPropPath: string) => {
         const parentFacet = propPathMapping.find(item => item.facetPropPath == facetPropPath)
-        var children: { label: string, id: number, children: Object, facetPropPath: string }[] = []
+        var children: { label: string, id: string, children: Object, facetPropPath: string }[] = []
         const responseFacets = response.facets
         if (responseFacets === undefined) {return}
         const responseFacetChildren =
@@ -85,16 +85,16 @@ export const getAlgoliaFacets = function(algoliaIndex : SearchIndex, propPathMap
             if (facet == info[0]) {
               filtered.push({
                 label: childFacetInfo, 
-                id: facetId++,
+                id: childFacetInfo,
                 facetPropPath: `${parentFacet?.facetSubpropPath}`
               })
             }
            return filtered;
           }
-          , Array<{label: string, id: number, facetPropPath: string}>())
+          , Array<{label: string, id: string, facetPropPath: string}>())
           children.push({
             label: facet,
-            id: facetId++,
+            id: facet,
             children: childrenSubfacets,
             facetPropPath: facetPropPath
           })
@@ -102,7 +102,7 @@ export const getAlgoliaFacets = function(algoliaIndex : SearchIndex, propPathMap
         if (children.length > 0) {
           facetData.push({
             label: parentFacet?.label || '',
-            id: facetId++,
+            id: parentFacet?.label || '',
             children: children,
             key: facetPropPath
           })

--- a/utils/algolia.ts
+++ b/utils/algolia.ts
@@ -57,7 +57,6 @@ export const getAlgoliaFacets = function(algoliaIndex : SearchIndex, propPathMap
   const facetPropPaths = propPathMapping.map(item => item.facetPropPath)
   const facetSubpropPaths = propPathMapping.map(item => item.facetSubpropPath)
   var facetData: { label: string, id: string, children: object[], key: string }[] = []
-  var facetId = 0
   return algoliaIndex
     .search('', {
       hitsPerPage: 0,


### PR DESCRIPTION
Addresses this ticket: https://www.wrike.com/open.htm?id=1593457431

Instead of assigning a dynamic int id on the fly, we now assign the facet label as the id so that the id's do not change when a new facet gets added to Algolia