### PR TITLE
Add tooltip for search related datasets

### DIFF
--- a/components/DatasetDetails/SimilarDatasetsInfoBox.vue
+++ b/components/DatasetDetails/SimilarDatasetsInfoBox.vue
@@ -2,8 +2,23 @@
   <client-only>
     <div class="mt-16 similar-datasets-container">
       <div class="header">
-        <div v-if="datasetTypeName === 'dataset'" class="p-8 mb-0">Search related datasets</div>
-        <div v-else class="p-8 mb-0">Search related models/simulations</div>
+        <div class="header-content">
+          <div v-if="datasetTypeName === 'dataset'" class="p-8 mb-0">Search related datasets</div>
+          <div v-else class="p-8 mb-0">Search related models/simulations</div>
+          <el-popover
+            width="160"
+            trigger="hover"
+            :append-to-body=false
+            class="popover"
+          >
+            <template v-slot:reference>
+              <svgo-icon-help class="help-icon"/>
+            </template>
+            <div>
+              Click a button below to search within that facet.
+            </div>
+          </el-popover>
+        </div>
         <hr />
       </div>
       <div class="px-8">
@@ -248,6 +263,17 @@ hr {
 }
 .header {
   font-weight: 500;
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+}
+
+.help-icon {
+  color: $purple;
+  height: 1.5rem;
+  width: 1.5rem;
 }
 
 .facet-button {


### PR DESCRIPTION
This is for the sprint ticket - [Bug Submission: Trying to figure out Search related datasets](https://www.wrike.com/open.htm?id=1607056426)

Based on the requirement, `help icon` and `popover` are added.

<img width="355" alt="Screenshot 2025-03-28 at 10 38 05 AM" src="https://github.com/user-attachments/assets/cd0d7553-c04d-4891-a2c2-9e733612c1df" />
<img width="402" alt="Screenshot 2025-03-28 at 10 38 12 AM" src="https://github.com/user-attachments/assets/79c7e5a4-fbde-44f5-987b-4a842326bec4" />

