### PR TITLE
Fix for event ordering

### DIFF
--- a/components/FacetMenu/FacetRadioButtonDateCategory.vue
+++ b/components/FacetMenu/FacetRadioButtonDateCategory.vue
@@ -6,7 +6,9 @@
       class="indent"
       @change="selectedDateOptionChanged"
     >
-      <el-radio class="pb-16" :label="showAllOption" />
+      <el-radio class="pb-16" :value="showAllOption">
+        Show All
+      </el-radio>
       <radio-date-option
         v-for="(option, index) in dateOptions"
         :key="index"

--- a/components/FacetMenu/RadioDateOption.vue
+++ b/components/FacetMenu/RadioDateOption.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <el-radio class="mb-4" :label="label" />
+    <el-radio class="mb-4" :value="label">
+      {{ label }}
+    </el-radio>
     <div class="flex ml-0 mr-24">
       <el-select
         v-model="month"

--- a/pages/news-and-events/events/index.vue
+++ b/pages/news-and-events/events/index.vue
@@ -226,6 +226,7 @@ const showPastEventsDivider = computed(() => {
 watch(
   () => route.query,
   async () => {
+    // Have to do this anywhere we are setting eventsData.value in order to force reactivity to work since we are relying on nested reactivity causing some Vue reactivity quirkyness with eventsData.items.
     eventsData.value = { ...eventsData.value, items: [] }
     await nextTick()
     eventsData.value = await fetchEvents(
@@ -260,9 +261,6 @@ const onPaginationPageChange = async (page) => {
   const limit = eventsData.value?.limit || 10
   const offset = (page - 1) * limit || 0
   const response = await fetchEvents($contentfulClient, route.query.search, startLessThanDate.value, startGreaterThanOrEqualToDate.value, eventTypes.value, sortOrder.value, limit, offset)
-  // Have to do this in order to force reactivity to work since we are relying on nested reactivity causing some Vue reactivity quirkyness with eventsData.items.
-  // Without first resetting the items, eventhough eventData.items in the network response was coming back in the right order for page refresh and on page change, 
-  // for some reason they were rendering in the reverse order on page change (eventhough they looked correct and the same as in the network response during refresh) 
   eventsData.value = { ...eventsData.value, items: [] }
   await nextTick()
   eventsData.value = response


### PR DESCRIPTION
Tracked down and fixed quirky vue reactivity bug with SSR vs Client rendering of nested refs. This is to address: https://www.wrike.com/open.htm?id=1641570461