### PR TITLE
Prevent results reset on navigation to dataset page after search/sort

### DIFF
--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -275,7 +275,8 @@ export default {
         },
       ],
       titleColumnWidth: 300,
-      windowWidth: ''
+      windowWidth: '',
+      isComponentActive: true,
     }
   },
 
@@ -343,6 +344,7 @@ export default {
 
     '$route.query.search': {
       handler: function () {
+        if (!this.isComponentActive) return
         this.searchQuery = this.$route.query.search
         this.fetchResults()
       },
@@ -351,6 +353,7 @@ export default {
 
     '$route.query.datasetSort': {
       handler: function () {
+        if (!this.isComponentActive) return
         this.fetchResults()
       },
       immediate: true
@@ -366,6 +369,13 @@ export default {
 
   beforeMount: function () {
     this.windowWidth = window.innerWidth
+  },
+  beforeRouteLeave: function (to, from, next) {
+    this.isComponentActive = false
+    next()
+  },
+  activated: function () {
+    this.isComponentActive = true
   },
   mounted: function () {
     if (!this.$route.query.type) {


### PR DESCRIPTION
Previously, when a user applied search or sort filters on the dataset listing, the results were filtered, and the URL query parameters were updated accordingly. 

However, upon clicking an item to navigate to the dataset detail page, the listing briefly reset because the URL query parameters were removed during navigation. This triggered the watcher function for URL query changes, unintentionally causing the data reset before navigating away.

This PR fixes the issue by ensuring the watcher does not trigger a reset when navigating away from the listing page.

Example: Go to https://sparc.science/data?type=simulation&search=135 and click the dataset link.