### PR TITLE
Update mapviewer and simulationviewer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "sass": "^1.66.1"
   },
   "dependencies": {
-    "@abi-software/mapintegratedvuer": "1.10.1",
+    "@abi-software/mapintegratedvuer": "1.10.2",
     "@abi-software/plotcomponents": "^0.2.4",
     "@abi-software/plotdatahelpers": "^0.1.2",
-    "@abi-software/simulationvuer": "2.0.11",
+    "@abi-software/simulationvuer": "2.0.12",
     "@element-plus/nuxt": "^1.0.10",
     "@nuxtjs/sitemap": "^5.1.4",
     "@pinia-plugin-persistedstate/nuxt": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,10 +46,10 @@
     unplugin-vue-components "^0.26.0"
     vue "^3.4.15"
 
-"@abi-software/flatmapvuer@^1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.10.0.tgz#cf6d715575a0678eaecaf6f3d3a1262acfa5c690"
-  integrity sha512-0eBxq4jERdFhyNQD3QjIPlxxfJIr83PzxMIoz5POc8qlwD2YJK8VgOSz+x3ne9D5TM+n22roydpuV99CO2gaPw==
+"@abi-software/flatmapvuer@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.10.1.tgz#74bc4fd02f7578ed690e955f2ecbd8f8b7f89464"
+  integrity sha512-NEnBXK4iWN0KpviUhVYhtqSaYPRh/icXR6KTuXRVVSJyjfdDIZ0P9SvijoZbjZbpeYeVq3ElZObDOiMUyimrSA==
   dependencies:
     "@abi-software/map-utilities" "^1.6.0"
     "@abi-software/sparc-annotation" "0.3.2"
@@ -75,10 +75,10 @@
     unplugin-vue-components "^0.26.0"
     vue "^3.4.21"
 
-"@abi-software/map-side-bar@^2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-2.9.0.tgz#2c2e80313e32421935fe4b54ce2a3da018b223b8"
-  integrity sha512-FpCwfXn8VDBeznB7liPxP0QNaME3UKF1/il2SwwiLKn8ahUaxE8tG/khntKq7FdFtUUAc0bcbuZQrCmnihyoNw==
+"@abi-software/map-side-bar@^2.9.1":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-2.9.1.tgz#e66e02e90cf53034e11bed8c889cd693b8053e71"
+  integrity sha512-8gBHX8sl5juP+aI0LWJKhKoiWuKp0XJl1hebcyzIuF+K9CVZaMExj4hnHYKj4UoOHeM/41dTJdey9/vknUUpZg==
   dependencies:
     "@abi-software/gallery" "^1.1.2"
     "@abi-software/map-utilities" "^1.6.0"
@@ -106,17 +106,17 @@
     mitt "^3.0.1"
     vue "^3.4.21"
 
-"@abi-software/mapintegratedvuer@1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.10.1.tgz#79e06fd474903d88bf433d97eb81c8e0dc504f7f"
-  integrity sha512-lJPzcv8KCGD1PnG7ZJaPanp9P/yDegvvVoTwEhR1AGVPOn2lLJ5FcHTgrTIBdL1H/8oX5dLRui94gCvzyq5ZQg==
+"@abi-software/mapintegratedvuer@1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.10.2.tgz#4cb75a030be14c40a0329e5bb7f8a865d222a48b"
+  integrity sha512-lksDD0/vaBIZ9xqJ0JWHmvRphwJZGuiLisfLNKv0HlJiaIRo6IUBtwjCWNB2aUIud+2CzUuiijxLS9yBcjB47g==
   dependencies:
-    "@abi-software/flatmapvuer" "^1.10.0"
-    "@abi-software/map-side-bar" "^2.9.0"
+    "@abi-software/flatmapvuer" "^1.10.1"
+    "@abi-software/map-side-bar" "^2.9.1"
     "@abi-software/map-utilities" "^1.6.0"
     "@abi-software/plotvuer" "1.0.4"
     "@abi-software/scaffoldvuer" "^1.10.0"
-    "@abi-software/simulationvuer" "^2.0.11"
+    "@abi-software/simulationvuer" "^2.0.12"
     "@abi-software/sparc-annotation" "0.3.2"
     "@abi-software/svg-sprite" "^1.0.1"
     "@element-plus/icons-vue" "^2.3.1"
@@ -185,10 +185,10 @@
     vue3-component-svg-sprite "^0.0.1"
     zincjs "^1.14.0"
 
-"@abi-software/simulationvuer@2.0.11", "@abi-software/simulationvuer@^2.0.11":
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/@abi-software/simulationvuer/-/simulationvuer-2.0.11.tgz#2663cb3c77cb1ecd5b7f1e0c0c21a171052f1b44"
-  integrity sha512-LdhCayFyseE9Ncs/4jaMdBOAk4sijR25cV2Sf8VTwn9dlwkA9AZxmaXmrb4y5SxjSpsF/+0T0hKD+ym7dCGTRQ==
+"@abi-software/simulationvuer@2.0.12", "@abi-software/simulationvuer@^2.0.12":
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/@abi-software/simulationvuer/-/simulationvuer-2.0.12.tgz#c0a37ea12a4279810cd9c756d3d68c34b43946c0"
+  integrity sha512-7M2rxnAo78zfbLYoJhaREvaQ4S5maBrIgFBH5eO44cozAzNNJqdr5HlkDHBf9cJ2rR/w9ckZav2U3NycVqf3Ng==
   dependencies:
     "@abi-software/plotvuer" "1.0.4"
     element-plus "2.8.4"


### PR DESCRIPTION
Simulationvuer will now download libOpenCOR module from jsdelivr.

Flatmaps in MapViewer will now hide unlisted connectivity and pathways on the connectivity explorer.

It can be viewed and tested here - https://alan-wu-sparc-app.herokuapp.com/