### PR TITLE
Files downloaded from dataset file page with specific viewer cannot be opened/unzipped

### DIFF
--- a/components/BiolucidaViewer/BiolucidaViewer.vue
+++ b/components/BiolucidaViewer/BiolucidaViewer.vue
@@ -43,6 +43,7 @@
         :biolucidaData="data"
         :datasetInfo="datasetInfo"
         :file="file"
+        @download-file="$emit('download-file', $event)"
       />
     </template>
     <p v-else class="error">

--- a/components/PlotViewer/PlotViewer.vue
+++ b/components/PlotViewer/PlotViewer.vue
@@ -25,6 +25,7 @@
         :plotType="plotType"
         :file="file"
         :datasetInfo="datasetInfo"
+        @download-file="$emit('download-file', $event)"
       />
     </div>
   </div>

--- a/components/SegmentationViewer/SegmentationViewer.vue
+++ b/components/SegmentationViewer/SegmentationViewer.vue
@@ -18,6 +18,7 @@
         :segmentationData="data"
         :datasetInfo="datasetInfo"
         :file="file"
+        @download-file="$emit('download-file', $event)"
       />
     </template>
     <p v-else class="error">

--- a/components/SimulationViewer/SimulationViewer.client.vue
+++ b/components/SimulationViewer/SimulationViewer.client.vue
@@ -6,6 +6,7 @@
     v-if="datasetInfo && file"
     :datasetInfo="datasetInfo"
     :file="file"
+    @download-file="$emit('download-file', $event)"
   />
 </template>
 

--- a/components/VideoViewer/VideoViewer.vue
+++ b/components/VideoViewer/VideoViewer.vue
@@ -12,6 +12,7 @@
     <generic-viewer-metadata
       :datasetInfo="datasetInfo"
       :file="file"
+      @download-file="$emit('download-file', $event)"
     />
   </div>
 </template>

--- a/components/ViewersMetadata/BiolucidaViewerMetadata.vue
+++ b/components/ViewersMetadata/BiolucidaViewerMetadata.vue
@@ -69,7 +69,7 @@
       </div>
     </div>
     <div v-if="filePath" class="pt-16">
-      <el-button @click="requestDownloadFile({...file, version: versionId})">
+      <el-button @click="executeDownload({...file, version: versionId})">
         Download file
       </el-button>
     </div>
@@ -78,7 +78,6 @@
 
 <script>
 import biolucida from '@/services/biolucida'
-import RequestDownloadFile from '@/mixins/request-download-file'
 import ImageScaling from '@/components/Images/ImageScaling.vue'
 import ImageChannels from '@/components/Images/ImageChannels.vue'
 import MarkedMixin from '@/mixins/marked'
@@ -115,7 +114,7 @@ export default {
       default: () => {}
     },
   },
-  mixins: [FileDetails, RequestDownloadFile],
+  mixins: [FileDetails],
   async setup(props) {
     try {
       const image_identifier = props.biolucidaData.biolucida_image_id
@@ -149,6 +148,11 @@ export default {
     versionId: function() {
       return propOr(undefined, 'version', this.datasetInfo)
     },
+  },
+  methods: {
+    executeDownload(file) {
+      this.$emit("download-file", file)
+    }
   }
 }
 </script>

--- a/components/ViewersMetadata/GenericViewerMetadata.vue
+++ b/components/ViewersMetadata/GenericViewerMetadata.vue
@@ -44,7 +44,7 @@
       </div>
     </div>
     <div class="pt-16">
-      <el-button @click="requestDownloadFile({...file, version: versionId})">
+      <el-button @click="executeDownload({...file, version: versionId})">
         Download file
       </el-button>
     </div>
@@ -52,7 +52,6 @@
 </template>
 
 <script>
-import RequestDownloadFile from '@/mixins/request-download-file'
 import FileDetails from '@/mixins/file-details'
 
 import { propOr } from 'ramda'
@@ -69,7 +68,7 @@ export default {
       default: () => {}
     },
   },
-  mixins: [FileDetails, RequestDownloadFile],
+  mixins: [FileDetails],
 
   computed: {
     datasetTitle: function() {
@@ -85,6 +84,11 @@ export default {
       return this.file.fileType
     },
   },
+  methods: {
+    executeDownload(file) {
+      this.$emit("download-file", file)
+    }
+  }
 }
 </script>
 

--- a/components/ViewersMetadata/PlotViewerMetadata.vue
+++ b/components/ViewersMetadata/PlotViewerMetadata.vue
@@ -44,7 +44,7 @@
       </div>
     </div>
     <div class="pt-16">
-      <el-button @click="requestDownloadFile({...file, version: versionId})">
+      <el-button @click="executeDownload({...file, version: versionId})">
         Download file
       </el-button>
     </div>
@@ -52,7 +52,6 @@
 </template>
 
 <script>
-import RequestDownloadFile from '@/mixins/request-download-file'
 import FileDetails from '@/mixins/file-details'
 
 import { propOr } from 'ramda'
@@ -73,7 +72,7 @@ export default {
       default: () => {}
     },
   },
-  mixins: [FileDetails, RequestDownloadFile],
+  mixins: [FileDetails],
 
   computed: {
     datasetTitle: function() {
@@ -86,6 +85,11 @@ export default {
       return propOr(undefined, "version", this.datasetInfo)
     },
   },
+  methods: {
+    executeDownload(file) {
+      this.$emit("download-file", file)
+    }
+  }
 }
 </script>
 

--- a/components/ViewersMetadata/SegmentationViewerMetadata.vue
+++ b/components/ViewersMetadata/SegmentationViewerMetadata.vue
@@ -77,7 +77,7 @@
       </div>
     </div>
     <div class="pt-16">
-      <el-button @click="requestDownloadFile({...file, version: versionId})">
+      <el-button @click="executeDownload({...file, version: versionId})">
         Download file
       </el-button>
     </div>
@@ -88,7 +88,6 @@
 import discover from '@/services/discover'
 import general from '@/services/general'
 
-import RequestDownloadFile from '@/mixins/request-download-file'
 import ImageScaling from '@/components/Images/ImageScaling.vue'
 import ImageChannels from '@/components/Images/ImageChannels.vue'
 import MarkedMixin from '@/mixins/marked'
@@ -122,7 +121,7 @@ export default {
       default: () => {}
     },
   },
-  mixins: [MarkedMixin, FileDetails, RequestDownloadFile],
+  mixins: [MarkedMixin, FileDetails],
 
   async setup(props) {
     try {
@@ -183,6 +182,11 @@ export default {
     },
     organ() {
       return pathOr("", ['atlas','organ'], this.segmentation_info)
+    }
+  },
+  methods: {
+    executeDownload(file) {
+      this.$emit("download-file", file)
     }
   }
 }

--- a/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
+++ b/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
@@ -14,15 +14,15 @@
         </span>
         <content-tab-card v-if="hasViewer" class="mt-24" :tabs="tabs" :active-tab-id="activeTabId">
           <biolucida-viewer v-if="hasBiolucidaViewer" v-show="activeTabId === 'imageViewer'" :data="biolucidaData"
-            :datasetInfo="datasetInfo" :file="file" />
+            :datasetInfo="datasetInfo" :file="file" @download-file="executeDownload" />
           <segmentation-viewer v-if="hasSegmentationViewer" v-show="activeTabId === 'segmentationViewer'"
-            :data="segmentationData" :datasetInfo="datasetInfo" :file="file" />
+            :data="segmentationData" :datasetInfo="datasetInfo" :file="file" @download-file="executeDownload" />
           <simulation-viewer v-if="hasSimulationViewer" v-show="activeTabId === 'simulationViewer'"
-            :apiLocation="apiLocation" :datasetInfo="datasetInfo" :file="file" />
+            :apiLocation="apiLocation" :datasetInfo="datasetInfo" :file="file" @download-file="executeDownload" />
           <plot-viewer v-if="hasPlotViewer" v-show="activeTabId === 'plotViewer'" :plotInfo="plotInfo"
-            :datasetInfo="datasetInfo" :file="file" />
+            :datasetInfo="datasetInfo" :file="file" @download-file="executeDownload" />
           <video-viewer v-if="hasVideoViewer" v-show="activeTabId === 'videoViewer'" :videoData="videoData"
-            :videoSource="signedUrl" :datasetInfo="datasetInfo" :file="file" />
+            :videoSource="signedUrl" :datasetInfo="datasetInfo" :file="file" @download-file="executeDownload" />
         </content-tab-card>
         <file-viewer-metadata v-if="!hasViewer" :datasetInfo="datasetInfo" :file="file"
           @download-file="executeDownload" />


### PR DESCRIPTION
This PR is to fix the [issue](https://github.com/nih-sparc/sparc-app-issues/issues/166).

To replace all the RequestDownloadFile with the form-based approach.

There are two remaining - [imageviewer](https://github.com/nih-sparc/sparc-app-2/blob/main/pages/datasets/imageviewer/%5Bid%5D.vue#L71) and [timeseriesviewer](https://github.com/nih-sparc/sparc-app-2/blob/main/pages/datasets/timeseriesviewer/index.vue#L65), where I can not find any dataset that I can test with. I would assume these two are no longer used anywhere.