### PR TITLE
Add a loading mask on plot.

### DIFF
--- a/components/PlotViewer/PlotViewer.vue
+++ b/components/PlotViewer/PlotViewer.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="plot-viewer-page">
     <div class="container p-0">
-      <div class="plot-container">
+      <div class="plot-container" v-loading="isLoading">
         <div id="plotly_graph" ref="plotly_plot_ref" class="vue-plotly" />
         <client-only>
           <div class="plot-controls">


### PR DESCRIPTION
A simple fix to let user knows that a plot is being loaded.

A loading icon should appear until the plot is fully loaded - https://alan-wu-sparc-app.herokuapp.com/datasets/file/126/3?path=files/derivative/sub-ChAT-Male-Subject-1/sam-200309/20_0309.csv