### PR TITLE
added back in randomized featured dataset logic

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -142,8 +142,13 @@ const { data: featuredDataCategories, error: featuredDataCategoriesError } = use
 })
 
 const { data: featuredDatasets, error: featuredDatasetsError } = useAsyncData('featuredDatasets', async () => {
-  const response = await $axios.get(`${config.public.discover_api_host}/datasets/32`)
-  return [response.data]
+  try {
+    const response = await $axios.get(`${config.public.portal_api}/get_featured_dataset`)
+    return response.data?.datasets
+  } catch {
+    const response = await $axios.get(`${config.public.discover_api_host}/datasets/32`)
+    return [response.data]
+  }
 });
 
 const institutionId = computed(() => 


### PR DESCRIPTION
This logic was removed during portal downtime diagnosis months ago and was never added back in. Doing so now