### PR TITLE
added source code button to launch device on Osparc

### DIFF
--- a/components/DatasetDetails/SourceCodeInfo.vue
+++ b/components/DatasetDetails/SourceCodeInfo.vue
@@ -7,14 +7,26 @@
       The design and code files for the device are stored in a public repository on GitHUB. Please feel free to clone the repository for your usage.
     </div>
     <div class="mb-16"><span class="label4">Repository Link: </span><a target="_blank" :href="repoLink">{{ repoLink }}</a></div>
-    <a
-      :href="repoLink"
+    <div class="flex-col">
+      <a
+        class="fit-width"
+        :href="repoLink"
+        target="_blank"
+      >
+        <el-button>
+          Visit Repository <svgo-icon-open class="icon-open" />
+        </el-button>
+      </a>
+      <a
+      class="fit-width"
+      :href="osparcLink"
       target="_blank"
-    >
-      <el-button>
-        Visit Repository <svgo-icon-open class="icon-open" />
-      </el-button>
-    </a>
+      >
+        <el-button class="secondary no-shadow">
+          Run on Osparc <svgo-icon-open class="icon-open" />
+        </el-button>
+      </a>
+    </div>
   </div>
 </template>
 
@@ -23,6 +35,11 @@ export default {
   name: 'SourceCodeInfo',
   props: {
     repoLink: {
+      type: String,
+      default: () => "",
+      required: true
+    },
+    osparcLink: {
       type: String,
       default: () => "",
       required: true
@@ -36,5 +53,16 @@ export default {
   height: 1.5rem;
   width: 1.5rem;
   margin-top: 2px;
+}
+.flex-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.fit-width {
+  width: fit-content;
+}
+.no-shadow {
+  box-shadow: none;
 }
 </style>

--- a/pages/datasets/[datasetId].vue
+++ b/pages/datasets/[datasetId].vue
@@ -75,7 +75,7 @@
                   :associated-projects="associatedProjects" :awards="sparcAwards"/>
                 <citation-details class="body1" v-show="activeTabId === 'cite'" :doi-value="datasetInfo.doi" />
                 <dataset-files-info class="body1" v-if="hasFiles" v-show="activeTabId === 'files'" />
-                <source-code-info class="body1" v-if="hasSourceCode" v-show="activeTabId === 'source'" :repoLink="sourceCodeLink"/>
+                <source-code-info class="body1" v-if="hasSourceCode" v-show="activeTabId === 'source'" :repoLink="sourceCodeLink" :osparcLink="osparcLink" />
                 <images-gallery class="body1" :markdown="markdown.markdownTop" v-show="activeTabId === 'images'" />
                 <div class="body1" v-show="activeTabId === 'metrics'">
                   <div v-if="hasCitations">
@@ -563,6 +563,10 @@ export default {
     },
     sourceCodeLink: function () {
       return pathOr(null, ['release','repoUrl'], this.datasetInfo)
+    },
+    osparcLink: function () {
+      // using axios, get osparc file_viewers from /get_osparc_data API endpoint
+      return `${this.$config.public.osparc_host}view?file_type=IPYNB&viewer_key=simcore/services/dynamic/jupyter-math&viewer_version=2.0.9&download_link=https://api.pennsieve.io/discover/datasets/${this.datasetId}/versions/1/metadata&file_size=1`
     },
     numDownloads: function () {
       let numDownloads = 0;


### PR DESCRIPTION
This change introduces a `Run on Osparc` button to the `SourceCodeInfo` panel.

The URL provided right now works against Osparc, but will change in a short period of time to take into account other launch methods.

Related issue: https://github.com/nih-sparc/sparc-app-issues/issues/196