### PR TITLE
Ensure the Data & Models link is active on dataset detail pages.

### DIFF
--- a/components/Header/Header.vue
+++ b/components/Header/Header.vue
@@ -232,6 +232,11 @@ export default {
     activeLink: function(query) {
       if (this.firstPath.includes(query)) {
         return true
+      } else if (
+        query.split('?')[0].replace('/', '') === 'data' &&
+        this.firstPath.replace('/', '') === 'datasets'
+      ) {
+        return true
       } else {
         return false
       }


### PR DESCRIPTION
Based on [the wireframe](https://xd.adobe.com/view/dede3038-f5b7-4b25-835b-48bd5fd2fe56-8b8d/screen/367440aa-a912-4d0b-90b1-31057d32ff15/), the [Data & Models](https://sparc.science/datasets/442) link in the main navigation should be in an active state when browsing to dataset detail pages. 
This fix achieves this by adding a condition that checks for a mismatch between the query and location path for the terms `data` and `dataset`.