### PR TITLE
Update to map-viewer 1.12.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sass": "^1.66.1"
   },
   "dependencies": {
-    "@abi-software/mapintegratedvuer": "1.12.4",
+    "@abi-software/mapintegratedvuer": "1.12.5",
     "@abi-software/plotcomponents": "^0.2.4",
     "@abi-software/plotdatahelpers": "^0.1.2",
     "@abi-software/simulationvuer": "2.0.17",

--- a/pages/apps/maps/index.vue
+++ b/pages/apps/maps/index.vue
@@ -92,6 +92,8 @@ const getScaffoldEntry = async (portalApi, route, $axios, s3Bucket) => {
           label: `Dataset ${route.query.dataset_id}`,
           url: `${portalApi}/s3-resource/${path}`,
           viewUrl: route.query.ViewURL,
+          dataset_id: route.query.dataset_id,
+          dataset_version: route.query.dataset_version,
         }
       } else {
         return undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,12 +30,12 @@
     minisearch "^2.2.1"
     polylabel "^1.1.0"
 
-"@abi-software/flatmapvuer@1.11.2":
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.11.2.tgz#84101600acfbefd85b0618afb0b69050d3ddbb14"
-  integrity sha512-SsGpStUAKULNszb3o6+srHFQA1+ZuIYssgG1MfJIfzsqoVcJpOtzexA4yXe7OJoMwqsni4BmelgGFD2qK7B6Yw==
+"@abi-software/flatmapvuer@1.11.3":
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.11.3.tgz#5fe2ab752d126689ab5551d23cf44cb1a5ea5aad"
+  integrity sha512-xMlnwaouoUyrO/cTKZdQOPEQLvPOV1JDpEMVlp+vZMYEEMrFJlDeTg0AfOEJ0NSB85TJ4f7ySpVV9fXtm0eGaA==
   dependencies:
-    "@abi-software/map-utilities" "^1.7.1"
+    "@abi-software/map-utilities" "1.7.2"
     "@abi-software/sparc-annotation" "0.3.2"
     "@abi-software/svg-sprite" "1.0.2"
     "@element-plus/icons-vue" "^2.3.1"
@@ -106,12 +106,12 @@
     mitt "^3.0.1"
     vue "^3.4.21"
 
-"@abi-software/mapintegratedvuer@1.12.4":
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.12.4.tgz#94068936162cf53507a209253d135ae72b67f37b"
-  integrity sha512-cwW7zyAFKF6pf0/YrnomHB7XjpyiY8sgIr3n2I+qApLsq5Px7OZd5se4u9lHm/it9QA9fgafBmNAF4BN+K+dlQ==
+"@abi-software/mapintegratedvuer@1.12.5":
+  version "1.12.5"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.12.5.tgz#d1e81b55a9f4918c8928508bcc34b9af5bd67e81"
+  integrity sha512-YGFkh90GDDaSuKb2yIbNqbqm0IY37W+FWkkgQOSDeWsGbwNUU2jsDhH1kdD7cvYYrMNejb9bFjZFnlP5NrmADA==
   dependencies:
-    "@abi-software/flatmapvuer" "1.11.2"
+    "@abi-software/flatmapvuer" "1.11.3"
     "@abi-software/map-side-bar" "2.10.4"
     "@abi-software/map-utilities" "1.7.2"
     "@abi-software/plotvuer" "1.0.5"


### PR DESCRIPTION
Update map-viewer to 1.12.5.

Changes:

- Support upcoming changes in to be promoted flatmaps

Bug fixes:

- Some links in contextual cards are broken when the scaffold is opened directly from the portal. [Example](https://sparc.science/apps/maps?type=scaffold&dataset_id=426&dataset_version=4&file_path=files/derivative/sub-f006/L/060-visualization/f006_left_human_vagus_metadata.json) See screenshot - the view source button

<img width="562" height="347" alt="image" src="https://github.com/user-attachments/assets/cdc065e4-c111-4f64-8b3f-bcb460a1b5fd" />


This can be tested here - https://alan-wu-sparc-app.herokuapp.com/