### PR TITLE
Bugfix: Open species from URL 

### DIFF
--- a/pages/apps/maps/index.vue
+++ b/pages/apps/maps/index.vue
@@ -32,8 +32,8 @@
               </template>
               <template #default>
                 <div class="popover-content" style="display: flex; flex-direction: column; gap: 0.5rem">
-                  <el-button 
-                    v-for="entry in mapEntries[item.buttonText]" 
+                  <el-button
+                    v-for="entry in mapEntries[item.buttonText]"
                     @click="setCurrentEntry(entry, item.buttonText)"
                   >
                     {{ entry }}
@@ -598,11 +598,13 @@ export default {
     },
     currentEntryUpdated: function () {
       if (this._instance && this.currentEntry) {
-        this._instance.setCurrentEntry(this.currentEntry)
+        this.$nextTick(() => {
+          this._instance.setCurrentEntry(this.currentEntry)
+        })
       }
     },
     setCurrentEntry: function (entry, type) {
-      let mapEntry = {}      
+      let mapEntry = {}
       if (type === 'AC Map') {
         mapEntry = {type: 'MultiFlatmap', resource: entry}
       } else if (type === '3D Whole Body') {

--- a/tests/cypress/e2e/mapsviewer.cy.js
+++ b/tests/cypress/e2e/mapsviewer.cy.js
@@ -148,6 +148,20 @@ mapTypes.forEach((map) => {
         })
       })
 
+      it('Load AC map with Rat taxon and verify species selection', function () {
+        // Visit the URL with AC map type and Rat taxon
+        cy.visit('/apps/maps?type=ac&taxo=NCBITaxon:10114')
+
+        // Wait for the page to fully load
+        cy.waitForViewerContainer('.mapClass')
+        cy.waitForPageLoading()
+        cy.waitForMapLoading()
+
+        // Check that the species selector shows "Rat"
+        cy.get('.portalmapcontainer .contentvuer .component-container .el-select.select-box .el-select__selection .el-select__selected-item.el-select__placeholder')
+          .should('contain.text', 'Rat')
+      })
+
       taxonModels.forEach((model, index) => {
 
         it(`Connectivity explorer for ${model}`, function () {


### PR DESCRIPTION
### Description
Resolved the issue that prevented the app from opening different species from the apps page, and added a corresponding unit test to ensure it works as expected.

### Type of change
Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
I have done manual testing by loading the maps page with different URL queries and verified that the species from the URL are loaded correctly.

### Checklist:

- [x]  I have performed a self-review of my own code
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works
- [x]  I have utilised components from the Design System Library where applicable