### PR TITLE
Subconsortia project page changes

### DIFF
--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -257,7 +257,7 @@ export default {
           }
         })
       })
-      return institutions.length > 0 ? institutionNames.join(", ") : 'None specified'
+      return institutionNames.length > 0 ? institutionNames.join(", ") : 'None specified'
     }
   },
 }

--- a/components/DatasetDetails/DatasetAboutInfo.vue
+++ b/components/DatasetDetails/DatasetAboutInfo.vue
@@ -70,8 +70,8 @@
         Institution(s): 
       </span>
       <span v-if="associatedProjects == null || associatedProjects.length < 1">None specified</span>
-      <span v-else v-for="(project, index) in associatedProjects" :key="index">
-        {{ getProjectInstitution(project) }}<span v-if="index < associatedProjects.length - 1">, </span>
+      <span v-else>
+        {{ associatedProjectsInstitutionNames }}
       </span>
     </div>
     <hr />
@@ -162,18 +162,7 @@ export default {
       const fields = propOr(null, 'fields', associatedProject)
       const title = propOr(null, 'title', fields)
       return title ?? 'N/A'
-    },
-    /**
-     * Compute the project institution
-     * @returns {String}
-     */
-    getProjectInstitution: function(associatedProject) {
-      const fields = propOr(null, 'fields', associatedProject)
-      const institution = propOr(null, 'institution', fields)
-      const institutionFields = propOr(null, 'fields', institution)
-      const institutionName = propOr(null, 'name', institutionFields)
-      return institutionName ?? 'N/A'
-    },
+    }
   },
 
   computed: {
@@ -255,6 +244,20 @@ export default {
           return projectAwards.some(projectAward => pathOr('', ['fields', 'title'], projectAward) === awardId)
         })
       })
+    },
+    associatedProjectsInstitutionNames() {
+      let institutionNames = []
+      this.associatedProjects.forEach((project) => {
+        const fields = propOr(null, 'fields', project)
+        const institutions = propOr([], 'institutions', fields)
+        institutions.forEach((institution) => {
+          const institutionName = pathOr(null, ['fields', 'name'], institution)
+          if (institutionName != null && !institutionNames.includes(institutionName)) {
+            institutionNames.push(institutionName)
+          }
+        })
+      })
+      return institutions.length > 0 ? institutionNames.join(", ") : 'None specified'
     }
   },
 }

--- a/components/Gallery/GalleryItems/HighlightCard.vue
+++ b/components/Gallery/GalleryItems/HighlightCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-card :style="{ border: 'none', maxWidth: width + 'rem' }" class="card">
+  <el-card :style="{ border: 'none', maxWidth: '100%' }" class="card">
     <news-list-item
       :item="item"
     />

--- a/components/Gallery/GalleryItems/ResourceCard.vue
+++ b/components/Gallery/GalleryItems/ResourceCard.vue
@@ -1,27 +1,30 @@
 <template>
-  <el-card :style="{ border: 'none', maxWidth: width + 'rem' }" class="card">
-    <div class="image-container mb-16">
-      <img class="thumbnail" :src="thumbnailUrl" alt="thumbnail loading ..." />
-    </div>
-    <div class="title-container">
-      <div class="title heading2">
-        {{title}}
+  <el-card :style="{ border: 'none', maxWidth: '100%' }" class="card">
+    <div class="horizontal-card-content">
+      <div class="card-left-section mr-16">
+        <div class="image-container mb-16">
+          <img class="thumbnail" :src="thumbnailUrl" alt="thumbnail loading ..." />
+        </div>
       </div>
-      <sparc-pill class="pill ml-16" v-if="showSparcTag">
-        SPARC Program
-      </sparc-pill>
+      <div class="card-right-section">
+        <div class="title-container">
+          <div class="title heading2">
+            {{title}}
+          </div>
+        </div>
+        <div class="heading3">
+          {{subtitle}}
+        </div>
+        <div class="body1 mb-16">
+          {{truncatedDescription}}
+        </div>
+        <a v-if="buttonLink !== null" :href="buttonLink">
+          <el-button class="secondary">
+            Learn More
+          </el-button>
+        </a>
+      </div>
     </div>
-    <div class="heading3">
-      {{subtitle}}
-    </div>
-    <div class="body1 mb-16">
-      {{truncatedDescription}}
-    </div>
-    <a v-if="buttonLink !== null" :href="buttonLink">
-      <el-button class="secondary">
-        Learn More
-      </el-button>
-    </a>
   </el-card>
 </template>
 
@@ -104,8 +107,24 @@ export default {
   border: 2px solid $lineColor1;
   padding: .5rem;
   background-color: white;
+  max-width: 10rem;
 }
 .pill {
   height: fit-content;
+}
+.horizontal-card-content {
+  display: flex; /* Makes this a flex container */
+}
+
+.card-image {
+  width: 150px; /* Set a specific width for your image */
+  margin-right: 20px; /* Add some space between the image and the text */
+}
+
+.card-right-section {
+  /* This content will take up the remaining space */
+  flex-grow: 1;
+  max-height: 10rem;
+  overflow-y: auto;
 }
 </style>

--- a/components/SearchResults/ProjectSearchResults.vue
+++ b/components/SearchResults/ProjectSearchResults.vue
@@ -3,7 +3,7 @@
     <el-table-column width="160">
       <template v-slot="scope">
         <div class="image-container">
-          <img v-if="scope.row.fields.institutions" class="img-project" :src="getImageSrc(scope)"
+          <img v-if="scope.row.fields.institution" class="img-project" :src="getImageSrc(scope)"
             :alt="getImageAlt(scope)" />
         </div>
       </template>
@@ -88,7 +88,7 @@ export default {
      * @returns {String}
      */
     getImageSrc: function (scope) {
-      return pathOr('', ['row', 'fields', 'institutions', 0, 'fields', 'logo', 'fields', 'file', 'url'], scope)
+      return pathOr('', ['row', 'fields', 'institution', 'fields', 'logo', 'fields', 'file', 'url'], scope)
     },
     /**
      * Get image source
@@ -96,8 +96,8 @@ export default {
      * @returns {String}
      */
     getImageAlt: function (scope) {
-      const defaultText = `Logo for ${pathOr('', ['row', 'fields', 'institutions', 0, 'fields', 'name'], scope)}`
-      return pathOr(defaultText, ['row', 'fields', 'institutions', 0, 'fields', 'logo', 'fields', 'file', 'description'], scope)
+      const defaultText = `Logo for ${pathOr('', ['row', 'fields', 'institution', 'fields', 'name'], scope)}`
+      return pathOr(defaultText, ['row', 'fields', 'institution', 'fields', 'logo', 'fields', 'file', 'description'], scope)
     },
     
     /**

--- a/mixins/consortia/index.js
+++ b/mixins/consortia/index.js
@@ -22,7 +22,7 @@ export default {
         { backgroundColor: `#${firstColor}` } : thirdColor == undefined ?
         { backgroundImage: `linear-gradient(#${firstColor}, #${secondColor}` } :    
         { backgroundImage: `linear-gradient(#${firstColor}, #${secondColor}, #${thirdColor}` }
-      style = { ...style, '--button-and-link-color': `#${buttonAndLinkColor}`, '--button-and-link-secondary-color': `#${buttonAndLinkColor}16` }
+      style = { ...style, '--button-and-link-color': `#${buttonAndLinkColor}`, '--button-and-link-secondary-color': `#${buttonAndLinkColor}16`, }
       this.consortiaStyle = style
     },
   }

--- a/pages/about/consortia/[id].vue
+++ b/pages/about/consortia/[id].vue
@@ -49,8 +49,18 @@
         <projects-and-datasets-card :title="featuredDataset.title" :description="featuredDataset.description"
           :banner="featuredDataset.banner" :link="featuredDatasetLink" button-text="View Dataset" />
       </div>
+      <div v-if="associatedTools.length > 0" class="gallery-items-container p-24 mt-32">
+        <div class="heading2 mb-16">
+          {{ associatedToolsTitle }}
+        </div>
+        <gallery
+          class="resources-gallery mb-16"
+          galleryItemType="resources"
+          :items="associatedTools"
+        />
+      </div>
       <div v-if="highlights.length > 0" class="gallery-items-container p-24 mt-32">
-        <div class="heading2 mb-16">Highlights</div>
+        <div class="heading2 mb-16">News</div>
         <gallery galleryItemType="highlights" :cardWidth="68" :items="highlights" />
       </div>
       <div v-if="learnMore.length > 0" class="subpage">
@@ -118,6 +128,8 @@ const whoWeAreButtonLink = computed(() => pathOr('', ['fields', 'whoWeAreButtonL
 const ourResearch = computed(() => pathOr('', ['fields', 'ourResearch'], consortiaItem.value))
 const ourResearchButtonText = computed(() => pathOr('', ['fields', 'ourResearchButtonText'], consortiaItem.value))
 const ourResearchButtonLink = computed(() => pathOr('', ['fields', 'ourResearchButtonLink'], consortiaItem.value))
+const associatedToolsTitle = computed(() => pathOr('Tools & Resources', ['fields', 'associatedToolsTitle'], consortiaItem.value))
+const associatedTools = computed(() => pathOr([], ['fields', 'associatedTools'], consortiaItem.value))
 //Temporarily disable RE-JOIN dataset button until RE-JOIN datasets are available
 const displayOurResearchButton = computed(() => !ourResearchButtonLink.value.includes('selectedFacetIds=RE-JOIN'))
 const learnMore = computed(() => pathOr([], ['fields', 'learnMore'], consortiaItem.value))
@@ -142,15 +154,15 @@ const featuredDatasetLink = computed(() => {
   return {
     isInternal: true,
     path: datasetPath,
-  };
-});
+  }
+})
 
-const featuredDatasetIdKey = computed(() => `${consortiaItem.value.fields.slug}_featuredDatasetId`);
-const featuredDatasetIdsKey = computed(() => `${consortiaItem.value.fields.slug}_featuredDatasetIds`);
-const listOfAvailableDatasetIdsKey = computed(() => `${consortiaItem.value.fields.slug}_listOfAvailableDatasetIds`);
-const organizationIdFilterKey = computed(() => `${consortiaItem.value.fields.slug}_organizationIdFilter`);
-const dateToShowFeaturedDatasetsUntilKey = computed(() => `${consortiaItem.value.fields.slug}_dateToShowFeaturedDatasetsUntil`);
-const timeDeltaForFeaturedDatasetsKey = computed(() => `${consortiaItem.value.fields.slug}_timeDeltaForFeaturedDatasets`);
+const featuredDatasetIdKey = computed(() => `${consortiaItem.value?.fields.slug}_featuredDatasetId`);
+const featuredDatasetIdsKey = computed(() => `${consortiaItem.value?.fields.slug}_featuredDatasetIds`);
+const listOfAvailableDatasetIdsKey = computed(() => `${consortiaItem.value?.fields.slug}_listOfAvailableDatasetIds`);
+const organizationIdFilterKey = computed(() => `${consortiaItem.value?.fields.slug}_organizationIdFilter`);
+const dateToShowFeaturedDatasetsUntilKey = computed(() => `${consortiaItem.value?.fields.slug}_dateToShowFeaturedDatasetsUntil`);
+const timeDeltaForFeaturedDatasetsKey = computed(() => `${consortiaItem.value?.fields.slug}_timeDeltaForFeaturedDatasets`);
 
 const featuredDatasetId = ref(null);
 const featuredDataset = ref({});
@@ -343,5 +355,8 @@ onMounted(async () => {
   border-color: var(--consortia-tooltip-color) !important;
   color: $grey !important;
   border-radius: 4px;
+}
+:deep(.resources-gallery-strip>.card-line) {
+  display: block !important;
 }
 </style>

--- a/pages/about/projects/[projectId].vue
+++ b/pages/about/projects/[projectId].vue
@@ -10,65 +10,130 @@
   <div :style="consortiaStyle" class="page pb-32">
     <breadcrumb :breadcrumb="breadcrumb" :title="title" />
     <div class="container">
-      <el-row class="row space-between">
-        <el-col class="subpage projects-subpage projects-details-container" :span="showAssociatedDatasets ? 17 : 24"
-          :xs="24">
-          <div ref="projectDetailsContainer">
-            <div class="row">
-              <div class="col image-container p-16 mb-8">
-                <img class="image" :src="getImageSrc" :alt="getImageAlt" />
-              </div>
-              <h1 class="col heading2 pl-16">
-                {{ title }}
-              </h1>
+      <div class="subpage projects-subpage projects-details-container">
+        <div ref="projectDetailsContainer">
+          <div class="row">
+            <div class="col image-container p-16 mb-8">
+              <img class="image" :src="getImageSrc" :alt="getImageAlt" />
             </div>
-            <div v-if="focus" class="body1">
-              FOCUS: <span class="label4">{{ focus }}</span>
+            <h1 class="col heading2 pl-16">
+              {{ title }}
+            </h1>
+          </div>
+          <div v-if="focus" class="body1">
+            FOCUS: <span class="label4">{{ focus }}</span>
+          </div>
+          <div v-if="investigators" class="body1 mb-4">
+            PRINCIPAL INVESTIGATOR(S): <span class="label4">{{ investigators.join(', ') }}</span>
+          </div>
+          <div v-if="institutions" class="body1 mb-4">
+            INSTITUTION(S): <span class="label4">{{ institutions }}</span>
+          </div>
+          <div v-if="fundingProgram.length > 0" class="body1 mb-4">
+            FUNDING PROGRAM(S): <span class="label4">{{ fundingProgram.join(', ') }}</span>
+          </div>
+          <div v-if="awards.length > 0" class="body1">
+            AWARD(S):
+            <span v-for="(award, index) in awards" :key=award.title class="body1">
+              <a class="link1" :href="award.url" :target="!opensInNewTab(award.url) ? '_self' : '_blank'">
+              {{ award.title }}
+              <svgo-icon-open v-if="!isInternalLink(award.url)" class="icon-open" /><span v-if="index < awards.length - 1">, </span>
+            </a>
+            </span>
+          </div>
+          <hr class="mt-16" />
+          <div class="body1 content" v-html="parseMarkdown(description)" />
+          <div class="body1">
+            <div class="label4">
+              SHARE
             </div>
-            <div v-if="investigators" class="body1 mb-4">
-              PRINCIPAL INVESTIGATOR(S): <span class="label4">{{ investigators.join(', ') }}</span>
-            </div>
-            <div v-if="institutions" class="body1 mb-4">
-              INSTITUTION(S): <span class="label4">{{ institutions }}</span>
-            </div>
-            <div v-if="fundingProgram.length > 0" class="body1 mb-4">
-              FUNDING PROGRAM(S): <span class="label4">{{ fundingProgram.join(', ') }}</span>
-            </div>
-            <div v-if="awards.length > 0" class="body1">
-              AWARD(S):
-              <span v-for="(award, index) in awards" :key=award.title class="body1">
-                <a class="link1" :href="award.url" :target="!opensInNewTab(award.url) ? '_self' : '_blank'">
-                {{ award.title }}
-                <svgo-icon-open v-if="!isInternalLink(award.url)" class="icon-open" /><span v-if="index < awards.length - 1">, </span>
-              </a>
-              </span>
-            </div>
+            <share-links class="share-links" />
             <hr class="mt-16" />
-            <div class="body1 content" v-html="parseMarkdown(description)" />
-            <div class="body1">
-              <div class="label4">
-                SHARE
+            <nuxt-link class="label4" :to="allProjectsLink">
+              View All Projects >
+            </nuxt-link>
+          </div>
+        </div>
+      </div>
+      <div v-if="associatedDatasets.length > 0" class="subpage associated-subpage">
+        <div class="heading2">
+          Associated Content
+        </div>
+        <el-table :data="associatedDatasets" :show-header="false" empty-text="No Results">
+          <el-table-column prop="banner" label="Image" width="160">
+            <template v-slot="scope">
+              <div v-if="scope.row?.pennsieve">
+                <nuxt-link
+                  :to="{
+                    name: 'datasets-datasetId',
+                    params: { datasetId: scope.row.object_id },
+                    query: {
+                      type: getSearchResultsType(scope.row?.item)
+                    }
+                  }"
+                  class="img-dataset"
+                > 
+                  <img
+                    v-if="scope.row.pennsieve.banner"
+                    :src="scope.row.pennsieve.banner.uri"
+                    :alt="`Banner for ${scope.row?.item.name}`"
+                    height="128"
+                    width="128"
+                  />
+                  <sparc-pill v-if="scope.row?.item.published" v-show='scope.row.item.published.status == "embargo"'>
+                    Embargoed
+                  </sparc-pill>
+                </nuxt-link>
               </div>
-              <share-links class="share-links" />
-              <hr class="mt-16" />
-              <nuxt-link class="label4" :to="allProjectsLink">
-                View All Projects >
-              </nuxt-link>
-            </div>
-          </div>
-        </el-col>
-        <el-col v-if="showAssociatedDatasets" class="subpage associated-subpage" :span="6" :xs="24">
-          <div class="heading2">
-            Associated Content
-          </div>
-          <div class="associated-datasets-container pr-16" :style="{ maxHeight: associatedDatasetsMaxHeight + 'px' }">
-            <br />
-            <div v-for="(dataset, index) in associatedDatasets" :key="index" class="body4">
-              <dataset-card :id="Number(dataset.objectID)" />
-            </div>
-          </div>
-        </el-col>
-      </el-row>
+            </template>
+          </el-table-column>
+          <el-table-column
+            min-width="400"
+          >
+            <template v-slot:default="scope">
+              <div v-if="scope.row?.pennsieve">
+                <nuxt-link
+                  :to="{
+                    name: 'datasets-datasetId',
+                    params: {datasetId: scope.row.object_id },
+                    query: {
+                      type: getSearchResultsType(scope.row.item)
+                    }
+                  }"
+                  v-html="scope.row._highlightResult.item.name.value"
+                />
+                <div
+                  class="my-8"
+                  v-if="scope.row._highlightResult.item.description"
+                  v-html="scope.row._highlightResult.item.description.value"
+                />
+              </div>
+            </template>
+          </el-table-column>
+        </el-table>
+      </div>
+      <div v-if="associatedPublications.length > 0" class="subpage associated-subpage">
+        <div class="heading2">
+          Associated Publications
+        </div>
+        <el-table :data="associatedPublications" :show-header="false" empty-text="No Results">
+          <el-table-column
+            min-width="400"
+          >
+            <template v-slot:default="scope">
+              <div v-if="scope.row?.citation" v-html="getCitationsText(scope.row.citation)" />
+            </template>
+          </el-table-column>
+        </el-table>
+      </div>
+      <div v-if="associatedTools.length > 0" class="subpage associated-subpage">
+        <div class="heading2 mb-16">Associated Tools &amp; Resources</div>
+        <gallery
+          class="resources-gallery mr-16 mb-16"
+          galleryItemType="resources"
+          :items="associatedTools"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -80,12 +145,14 @@ import marked from '@/mixins/marked/index'
 import { isInternalLink, opensInNewTab } from '@/mixins/marked/index'
 import { pathOr, propOr, isEmpty } from 'ramda'
 import consortiaMixin from '@/mixins/consortia'
+import Gallery from '@/components/Gallery/Gallery.vue'
 import { ref } from 'vue'
 
 export default {
   name: 'ProjectDetails',
   components: {
     DatasetCard,
+    Gallery,
     ShareLinks
   },
   mixins: [consortiaMixin, marked],
@@ -96,22 +163,39 @@ export default {
     try {
       const project = await $contentfulClient.getEntry(route.params.projectId)
       const awards = pathOr(null, ['fields','awards'], project)
-      let associatedDatasets = []
 
-      await Promise.all(awards.map(async (award) => {
+      let associatedDatasetsResults = await Promise.all(awards.map(async (award) => {
         try {
           const { data } = await $axios.get(`${config.public.portal_api}/project/${award.fields.title}`)
-          if (Array.isArray(data) && data.length > 0)
-          associatedDatasets = associatedDatasets.concat(data)
+          return Array.isArray(data) && data.length > 0 ? data : []
         } catch (error) {
-          console.error(`Failed to fetch data for awardId ${award.fields.title}`, error)
+          console.error(`Failed to fetch associated datasets for awardId ${award.fields.title}`, error)
+          return []
         }
       }))
+
+      const associatedDatasets = ref(associatedDatasetsResults.flat())
+
+      let associatedPublicationsResults = associatedDatasets.value.length <= 0 ? [] :
+        await Promise.all(associatedDatasets.value.map(async (dataset) => {
+          try {
+            if (dataset == undefined) { return }
+            const { data } = await $axios.get(`${config.public.portal_api}/dataset_citations/${dataset['objectID']}`)
+            return propOr([], 'citations', data).filter((citation) => { return citation['relationship']?.toLowerCase() === 'cites'})
+          } catch (error) {
+            console.error(`Failed to fetch publication data for dataset ${dataset['objectID']}`, error)
+            return []
+          }
+        }))
+
+      const associatedPublications = ref(associatedPublicationsResults.flat())
+
       return {
         fields: project.fields,
         awards: awards.map(award => award.fields),
         associatedDatasets,
-        associatedDatasetsMaxHeight: ref(0)
+        associatedPublications,
+        associatedDatasetsMaxHeight: ref(0),
       }
     } catch (e) {
       console.error(e)
@@ -128,7 +212,7 @@ export default {
       handler: function(){
         this.associatedDatasetsMaxHeight = this.$refs.projectDetailsContainer.clientHeight - 19
       }
-    }
+    },
   },
 
   computed: {
@@ -199,8 +283,8 @@ export default {
     focus: function () {
       return propOr([], 'focus', this.fields).join(", ")
     },
-    showAssociatedDatasets: function () {
-      return !isEmpty(this.associatedDatasets)
+    associatedTools: function() {
+      return propOr([], 'associatedTools', this.fields)
     },
     allProjectsLink() {
       return `/about/projects?consortiaType=${this.fundingProgram}`
@@ -209,7 +293,21 @@ export default {
 
   methods: {
     isInternalLink,
-    opensInNewTab
+    opensInNewTab,
+    getSearchResultsType(item) {
+      return item !== undefined ? 
+        (item.types[0].name === 'computational model' ? 'simulation'
+          : item.types[0].name === 'device' ? 'device'
+          : undefined) :
+        undefined
+    },
+    getCitationsText(citation) {
+      const doiLinkIndex = citation.lastIndexOf("https://doi.org/"); // Find the doi link to remove and make it a href
+      if (doiLinkIndex === -1) { return citation }
+      const doiLink = citation.slice(doiLinkIndex, citation.length)
+      // Remove the last instance of the substring by slicing and concatenating the parts
+      return `${citation.slice(0, doiLinkIndex)}<u><a href="${doiLink}" target="_blank">${doiLink}</a></u>`
+    }
   }
 }
 </script>
@@ -221,9 +319,6 @@ export default {
 }
 .row {
   display: flex;
-}
-.space-between {
-  justify-content: space-between;
 }
 .image-container {
   display: flex;
@@ -280,6 +375,17 @@ hr {
   padding-right: 0rem !important;
   padding-top: 1rem !important;
   padding-bottom: 0 !important;
+  > .el-table {
+    max-height: 32rem;
+    overflow-y: auto;
+  }
+}
+.subpage {
+  margin: 0;
+  margin-top: 2rem;
+}
+:deep(.resources-gallery-strip>.card-line) {
+  display: block !important;
 }
 :deep(.container) {
   a {
@@ -296,5 +402,8 @@ hr {
     border-color: var(--button-and-link-color) !important;
     color: var(--button-and-link-color) !important;
   }
+}
+:deep(.el-table--enable-row-hover .el-table__body tr:hover>td.el-table__cell) {
+  background-color: white !important;
 }
 </style>

--- a/pages/about/projects/[projectId].vue
+++ b/pages/about/projects/[projectId].vue
@@ -252,10 +252,10 @@ export default {
      * @returns {String}
      */
     getImageSrc: function () {
-      return pathOr('', ['institutions', 0, 'fields', 'logo', 'fields', 'file', 'url'], this.fields)
+      return pathOr('', ['institution', 'fields', 'logo', 'fields', 'file', 'url'], this.fields)
     },
     getImageAlt: function () {
-      return pathOr('', ['institutions', 0, 'fields', 'logo', 'fields', 'file', 'description'], this.fields)
+      return pathOr('', ['institution', 'fields', 'logo', 'fields', 'file', 'description'], this.fields)
     },
     title: function () {
       return this.fields.title

--- a/pages/about/projects/[projectId].vue
+++ b/pages/about/projects/[projectId].vue
@@ -58,6 +58,18 @@
       <div v-if="associatedDatasets.length > 0" class="subpage associated-subpage">
         <div class="heading2">
           Associated Content
+          <el-tooltip
+            v-if="associatedContentTooltip"
+            placement="right-start"
+            effect="customized"
+          >
+            <template #default>
+              <svgo-icon-help class="help-icon"/>
+            </template>
+            <template #content>
+              {{ associatedContentTooltip }}
+            </template>
+          </el-tooltip>
         </div>
         <el-table :data="associatedDatasets" :show-header="false" empty-text="No Results">
           <el-table-column prop="banner" label="Image" width="160">
@@ -114,7 +126,19 @@
       </div>
       <div v-if="associatedPublications.length > 0" class="subpage associated-subpage">
         <div class="heading2">
-          Associated Publications
+          Associated Primary Publications
+          <el-tooltip
+            v-if="associatedPublicationsTooltip"
+            placement="right-start"
+            effect="customized"
+          >
+            <template #default>
+              <svgo-icon-help class="help-icon"/>
+            </template>
+            <template #content>
+              {{ associatedPublicationsTooltip }}
+            </template>
+          </el-tooltip>
         </div>
         <el-table :data="associatedPublications" :show-header="false" empty-text="No Results">
           <el-table-column
@@ -127,12 +151,49 @@
         </el-table>
       </div>
       <div v-if="associatedTools.length > 0" class="subpage associated-subpage">
-        <div class="heading2 mb-16">Associated Tools &amp; Resources</div>
+        <div class="heading2 mb-16">
+          {{ associatedToolsTitle }}
+          <el-tooltip
+            v-if="associatedToolsTooltip"
+            placement="right-start"
+            effect="customized"
+          >
+            <template #default>
+              <svgo-icon-help class="help-icon"/>
+            </template>
+            <template #content>
+              {{ associatedToolsTooltip }}
+            </template>
+          </el-tooltip>
+        </div>
         <gallery
           class="resources-gallery mr-16 mb-16"
           galleryItemType="resources"
           :items="associatedTools"
         />
+      </div>
+      <div v-if="highlights.length > 0" class="subpage">
+        <div class="heading2 mb-16">
+          Highlights
+          <el-tooltip
+            v-if="highlightsTooltip"
+            placement="right-start"
+            effect="customized"
+          >
+            <template #default>
+              <svgo-icon-help class="help-icon"/>
+            </template>
+            <template #content>
+              {{ highlightsTooltip }}
+            </template>
+          </el-tooltip>
+        </div>
+        <template v-for="(item, index) in highlights" :key="index">
+          <div>
+            <learn-more-card :about-details-item="item" />
+            <hr v-if="highlights.length > 1 && index != highlights.length - 1" />
+          </div>
+        </template>
       </div>
     </div>
   </div>
@@ -140,6 +201,7 @@
 
 <script>
 import DatasetCard from '@/components/DatasetCard/DatasetCard.vue'
+import LearnMoreCard from '@/components/LearnMoreCard/LearnMoreCard.vue';
 import ShareLinks from '@/components/ShareLinks/ShareLinks.vue'
 import marked from '@/mixins/marked/index'
 import { isInternalLink, opensInNewTab } from '@/mixins/marked/index'
@@ -153,6 +215,7 @@ export default {
   components: {
     DatasetCard,
     Gallery,
+    LearnMoreCard,
     ShareLinks
   },
   mixins: [consortiaMixin, marked],
@@ -266,6 +329,9 @@ export default {
     fundingProgram: function () {
       return this.fields.program
     },
+    associatedContentTooltip: function () {
+      return this.fields.associatedContentTooltip
+    },
     institutions: function () {
       let names = ''
       this.fields.institutions.forEach(institution => {
@@ -283,8 +349,23 @@ export default {
     focus: function () {
       return propOr([], 'focus', this.fields).join(", ")
     },
+    associatedPublicationsTooltip: function() {
+      return propOr(null, 'associatedPublicationsTooltip', this.fields)
+    },
     associatedTools: function() {
       return propOr([], 'associatedTools', this.fields)
+    },
+    associatedToolsTitle: function() {
+      return propOr('Associated Tools & Resources', 'associatedToolsTitle', this.fields)
+    },
+    associatedToolsTooltip: function() {
+      return propOr(null, 'associatedToolsTooltip', this.fields)
+    },
+    highlights: function() {
+      return propOr([], 'highlights', this.fields)
+    },
+    highlightsTooltip: function() {
+      return propOr(null, 'highlightsTooltip', this.fields)
     },
     allProjectsLink() {
       return `/about/projects?consortiaType=${this.fundingProgram}`
@@ -363,6 +444,11 @@ hr {
   width: 1.5rem;
   height: 1.5rem;
 }
+.help-icon {
+  color: var(--button-and-link-color);
+  height: 1.5rem;
+  width: 1.5rem;
+}
 .projects-details-container {
   height: fit-content;
 }
@@ -405,5 +491,14 @@ hr {
 }
 :deep(.el-table--enable-row-hover .el-table__body tr:hover>td.el-table__cell) {
   background-color: white !important;
+}
+:deep(.el-popper .el-popper__arrow::before) {
+  background-color: var(--button-and-link-secondary-color) !important;
+}
+:deep(.consortia-tooltips.el-popper) {
+  background: var(--button-and-link-secondary-color) !important;
+  border-color: var(--button-and-link-color) !important;
+  color: $grey !important;
+  border-radius: 4px;
 }
 </style>


### PR DESCRIPTION
Made changes project pages and consortia pages to allow subconsortia functionality shown here: https://xd.adobe.com/view/e0c6a404-1f78-4a33-95dc-0814fe67d314-b595/screen/a0101365-8a30-43ea-94ad-4abe644ed0f0/

Instead of subconsortias, we will use project pages to highlight 'subconsortia projects' such as REVA and VESPA to show work that has been completed among the different teams all on a singular page