### PR TITLE
Update to map-viewer 1.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sass": "^1.66.1"
   },
   "dependencies": {
-    "@abi-software/mapintegratedvuer": "1.13.0",
+    "@abi-software/mapintegratedvuer": "1.13.1",
     "@abi-software/plotcomponents": "^0.2.4",
     "@abi-software/plotdatahelpers": "^0.1.2",
     "@abi-software/simulationvuer": "2.0.17",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "string-width": "4.2.3",
     "mlly": "1.4.0",
     "vue": "3.4.21",
-    "@abi-software/map-utilities": "1.7.2"
+    "@abi-software/map-utilities": "^1.7.5",
+    "@abi-software/mapintegratedvuer/@abi-software/flatmapvuer/@abi-software/map-utilities": "1.7.5"
   },
   "engines": {
     "node": "18.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,10 +73,10 @@
     vue "^3.4.21"
     xss "^1.0.14"
 
-"@abi-software/map-utilities@1.7.2", "@abi-software/map-utilities@1.7.4", "@abi-software/map-utilities@1.7.5", "@abi-software/map-utilities@^1.6.0-beta.0", "@abi-software/map-utilities@^1.7.4":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-utilities/-/map-utilities-1.7.2.tgz#72fbe8f0fa5110037aef9794d1dc5d01a9d6ccb1"
-  integrity sha512-QFZk+TnZ4TYBFBiE+2UwpY0+l6wOdzTD4aTH/OkOwam+VBEGbHhXVoAUzslKNuQ1tja/GpskbiaU0MCdGyIdUQ==
+"@abi-software/map-utilities@1.7.2", "@abi-software/map-utilities@1.7.4", "@abi-software/map-utilities@1.7.5", "@abi-software/map-utilities@^1.6.0-beta.0", "@abi-software/map-utilities@^1.7.4", "@abi-software/map-utilities@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-utilities/-/map-utilities-1.7.5.tgz#b9bdce7b6902ae0b173b40083db0d1ff5d96edd1"
+  integrity sha512-3mCjdfEJwN5RnxBbWLU7U9WXiFW7jme70dmZIXy1pipKzqpg21IqC6hAfr/wVp16j6BUs4DD8ewl30Y+NTTgLA==
   dependencies:
     "@abi-software/svg-sprite" "^1.0.1"
     "@element-plus/icons-vue" "^2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,10 +86,10 @@
     mitt "^3.0.1"
     vue "^3.4.21"
 
-"@abi-software/mapintegratedvuer@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.13.0.tgz#72ac90d01e4f063b8129cb515cbba2feaa8c1c89"
-  integrity sha512-o44BodRyKzlP36Q6LVBaguiSle+pqNU9P339KPt9lTKvrNfnKxyHMLUP+rwVEfiXUHGqmr+hpnrMPDY+onRvnA==
+"@abi-software/mapintegratedvuer@1.13.1":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.13.1.tgz#738656e7af1b63a099167f63d34999e0438cc79f"
+  integrity sha512-Yazq10S16s6i9dYIEPDMKn/jlAXYfbBVmflLEvaUb5e+Y0YxOng6WXC6kpW/AlEXTu2Iy2SE91KvMnkawC1+2A==
   dependencies:
     "@abi-software/flatmapvuer" "1.11.4"
     "@abi-software/map-side-bar" "2.10.6"


### PR DESCRIPTION
Update to map-viewer 1.13.1

### Changes

- Disable flatmap minimap when there are more than four panes in map-viewer
- Make view/hide text consistent with the rest of the context card.
- Fix incorrect font family for View/Hide source data links on contextual card