### PR TITLE
Update map-viewer to 1.17.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "semver": "^7.7.3"
   },
   "dependencies": {
-    "@abi-software/mapintegratedvuer": "1.17.1",
+    "@abi-software/mapintegratedvuer": "1.17.2",
     "@abi-software/plotcomponents": "^0.2.4",
     "@abi-software/plotdatahelpers": "^0.1.2",
     "@abi-software/simulationvuer": "3.0.15",
@@ -67,7 +67,7 @@
     "string-width": "4.2.3",
     "mlly": "1.4.0",
     "vue": "3.4.21",
-    "@abi-software/flatmapvuer": "1.13.0",
+    "@abi-software/flatmapvuer": "1.13.1",
     "@deck.gl/core": "9.1.8",
     "@deck.gl/extensions": "9.1.8",
     "@deck.gl/geo-layers": "9.1.8",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "semver": "^7.7.3"
   },
   "dependencies": {
-    "@abi-software/mapintegratedvuer": "1.17.0",
+    "@abi-software/mapintegratedvuer": "1.17.1",
     "@abi-software/plotcomponents": "^0.2.4",
     "@abi-software/plotdatahelpers": "^0.1.2",
     "@abi-software/simulationvuer": "3.0.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,16 +67,29 @@
     mitt "^3.0.1"
     vue "^3.4.21"
 
-"@abi-software/mapintegratedvuer@1.17.0":
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.17.0.tgz#997be7c05ed0bc2967048e5653c1e39bb1fcdab2"
-  integrity sha512-FBF0JzNSp2NlpfBgBLWvXe49z5gleJv3Y59q0x9WvM/NxexAvXGjfZjbqqrvMtjD9IygyOkUcbQTVOZrGM68Fg==
+"@abi-software/map-utilities@1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-utilities/-/map-utilities-1.8.1.tgz#9f7dcae1ba19fdbc6df944d5fb138014171fbb23"
+  integrity sha512-yinECWuKKq75me+JQSjatw8zlPrK7vK0apwDp4lPh+GnfIw271q1EJ22veJDZuQJKd6U+wjjolrAIPLAcXVBQg==
+  dependencies:
+    "@abi-software/svg-sprite" "^1.0.1"
+    "@element-plus/icons-vue" "^2.3.1"
+    cytoscape "^3.30.2"
+    cytoscape-dagre "^2.5.0"
+    element-plus "2.8.4"
+    mitt "^3.0.1"
+    vue "^3.4.21"
+
+"@abi-software/mapintegratedvuer@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.17.1.tgz#1789171a1c1448445e5e2f1bd2f4716e6a9138ca"
+  integrity sha512-XQjWLOp58wWk16rHta5dFXGuJAh8I52D6dvPM7q76Q2jzOhdIDEHHCEedBYOakSh53FmFSN44XcpK5S/j2msLQ==
   dependencies:
     "@abi-software/flatmapvuer" "1.13.0"
     "@abi-software/map-side-bar" "2.14.0"
-    "@abi-software/map-utilities" "1.8.0"
+    "@abi-software/map-utilities" "1.8.1"
     "@abi-software/plotvuer" "1.0.7"
-    "@abi-software/scaffoldvuer" "1.14.0"
+    "@abi-software/scaffoldvuer" "1.14.1"
     "@abi-software/simulationvuer" "3.0.15"
     "@abi-software/sparc-annotation" "0.3.2"
     "@abi-software/svg-sprite" "1.0.4"
@@ -126,12 +139,12 @@
     vue-draggable-resizable "^2.2.0"
     vue-router "^4.2.5"
 
-"@abi-software/scaffoldvuer@1.14.0":
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/scaffoldvuer/-/scaffoldvuer-1.14.0.tgz#050437d244f2efd1c28a1c683cc68411dc5de8ef"
-  integrity sha512-BaU/BAEMzDG0JH9NeNFUV33Ktez/xR/XyMn89+3DE8+FeRP7hT0ritFjP5dhhMTm44+7pMATHuVwrnARzf8xWQ==
+"@abi-software/scaffoldvuer@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/scaffoldvuer/-/scaffoldvuer-1.14.1.tgz#ba237ed4092d4b9a35597b4c35b47af415c62254"
+  integrity sha512-SUJm4YNyTu3Gtqf9ZKdCcGICaX9MadQ5w6np68415d8FtDr8fvvLQjc89Lx1Gc38em2MZdZxcGnte25+QG+hnQ==
   dependencies:
-    "@abi-software/map-utilities" "1.8.0"
+    "@abi-software/map-utilities" "1.8.1"
     "@abi-software/sparc-annotation" "^0.3.2"
     "@abi-software/svg-sprite" "1.0.3"
     "@element-plus/icons-vue" "^2.3.1"
@@ -143,7 +156,7 @@
     unplugin-vue-components "^0.26.0"
     vue "^3.4.21"
     vue-router "^4.2.5"
-    zincjs "^1.16.10"
+    zincjs "^1.17.0"
 
 "@abi-software/simulationvuer@3.0.15":
   version "3.0.15"
@@ -16998,10 +17011,10 @@ zhead@^2.2.4:
   resolved "https://registry.yarnpkg.com/zhead/-/zhead-2.2.4.tgz#87cd1e2c3d2f465fa9f43b8db23f9716dfe6bed7"
   integrity sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==
 
-zincjs@^1.16.10:
-  version "1.16.10"
-  resolved "https://registry.yarnpkg.com/zincjs/-/zincjs-1.16.10.tgz#40db8d6b2a65babd92596ddef9e5f95f35073b7c"
-  integrity sha512-pjXO1QK8MDl3rQBw7LUYoqSw6HX42KS1Hu32AhTPL47O0hOQcIsDD2peZhHII7V7fcjcgpOEMLFCR6gzWzf+4Q==
+zincjs@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/zincjs/-/zincjs-1.17.0.tgz#827945d7260fa1f07abfee621cabb0a9a48b787c"
+  integrity sha512-eIVAHmFHHQSooXk8yv1KcOmH5vnnyyetuROGhG0pQkMUE4FOG+ZdlmH/HiWCDQjkPgYmRXYdCyciEEEBIrdyNQ==
   dependencies:
     css-element-queries "^1.2.2"
     lodash "^4.17.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,12 +7,12 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@abi-software/flatmapvuer@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.13.0.tgz#20ed85ff1d708ef7fbc4d3147d618a7749798ddf"
-  integrity sha512-7awYyJsTBgQfeWuoPbGuA5BlUh9et8h9ZzqvKS1qcQMQSKh7dgFm4ASr35cCANKrYfDc3BELWDgQoj5ZjqrXzg==
+"@abi-software/flatmapvuer@1.13.1":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.13.1.tgz#506beebc2f9d0e35c0a44a8eda53fd0c0944eefb"
+  integrity sha512-pyeG8i3owWLYOYlRBR1f22QRd7VTGT38fPeAJIciP0y9l9mPukIPnwlqA5BRoR29J7HkMqcqodfHfR/FRwOJPw==
   dependencies:
-    "@abi-software/map-utilities" "1.8.0"
+    "@abi-software/map-utilities" "1.8.1"
     "@abi-software/sparc-annotation" "0.3.2"
     "@abi-software/svg-sprite" "1.0.3"
     "@element-plus/icons-vue" "^2.3.1"
@@ -36,13 +36,13 @@
     unplugin-vue-components "^0.26.0"
     vue "^3.4.21"
 
-"@abi-software/map-side-bar@2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-2.14.0.tgz#65747fae851b32b4b421a8bbfefbfc0fe79c7ba1"
-  integrity sha512-k68pTgKUTfchmCWABlyIUOwka5DpiIOY/Oo1hNXnxl02jZXgKZtmt3vF1glvuUU0oCzJCnkCVScK1iSGh0tVfA==
+"@abi-software/map-side-bar@2.14.1":
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-2.14.1.tgz#a9cc7316b1ce4daa6182b4d303c6b0dda4263773"
+  integrity sha512-8fEcLeCv1gqbUluMPa2giRIbQOLzsH+7/wi/HkkOYptxDjlMg8YCgxOdkWL4Z+cUEkZuSm74cDDtlhiQr902pA==
   dependencies:
     "@abi-software/gallery" "1.3.0"
-    "@abi-software/map-utilities" "1.8.0"
+    "@abi-software/map-utilities" "1.8.1"
     "@abi-software/svg-sprite" "^1.0.2"
     "@element-plus/icons-vue" "^2.3.1"
     algoliasearch "^4.10.5"
@@ -53,19 +53,6 @@
     unplugin-vue-components "^0.26.0"
     vue "^3.4.21"
     xss "^1.0.14"
-
-"@abi-software/map-utilities@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-utilities/-/map-utilities-1.8.0.tgz#a6a818c0dd1d78837aff74b55089e281dd572aca"
-  integrity sha512-iMJZqr92P6w9v6cy5qL0gNQWnEAPuOlJUovL4BSWeXdCOegDGuAoFVQFuKYOj2yR7tP/W/Y8IYoZFp7xuHRAZg==
-  dependencies:
-    "@abi-software/svg-sprite" "^1.0.1"
-    "@element-plus/icons-vue" "^2.3.1"
-    cytoscape "^3.30.2"
-    cytoscape-dagre "^2.5.0"
-    element-plus "2.8.4"
-    mitt "^3.0.1"
-    vue "^3.4.21"
 
 "@abi-software/map-utilities@1.8.1":
   version "1.8.1"
@@ -80,13 +67,13 @@
     mitt "^3.0.1"
     vue "^3.4.21"
 
-"@abi-software/mapintegratedvuer@1.17.1":
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.17.1.tgz#1789171a1c1448445e5e2f1bd2f4716e6a9138ca"
-  integrity sha512-XQjWLOp58wWk16rHta5dFXGuJAh8I52D6dvPM7q76Q2jzOhdIDEHHCEedBYOakSh53FmFSN44XcpK5S/j2msLQ==
+"@abi-software/mapintegratedvuer@1.17.2":
+  version "1.17.2"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.17.2.tgz#2fc629788f1f0367f182a5c26d6f546c554f9927"
+  integrity sha512-RpLBa+68I+87Z3UCtnMn6IX+H/hN8gEzpdejy3MEDBWblZWEqg3rDpwUeF70ltAGQsqH8EW8Qfbu52S7jKNioA==
   dependencies:
-    "@abi-software/flatmapvuer" "1.13.0"
-    "@abi-software/map-side-bar" "2.14.0"
+    "@abi-software/flatmapvuer" "1.13.1"
+    "@abi-software/map-side-bar" "2.14.1"
     "@abi-software/map-utilities" "1.8.1"
     "@abi-software/plotvuer" "1.0.7"
     "@abi-software/scaffoldvuer" "1.14.1"


### PR DESCRIPTION
Map-viewer updates:

- Fix missing connectivity graph for ilx:composer paths
- Fix error when loading certain scaffold files 
