### PR TITLE
Fix OME-TIFF viewer for interleaved RGB files and add tile caching

### DIFF
--- a/components/OmeViewer/OmeViewer.client.vue
+++ b/components/OmeViewer/OmeViewer.client.vue
@@ -13,6 +13,7 @@
           v-if="presignedUrl"
           :source="presignedUrl"
           source-type="ome-tiff"
+          :cache-id="filePath"
         />
       </div>
       <generic-viewer-metadata
@@ -57,6 +58,7 @@ export default defineComponent({
     const config = useRuntimeConfig()
 
     const presignedUrl = ref('')
+    const filePath = ref('')
     const isLoading = ref(true)
     const hasError = ref(false)
     const errorMessage = ref('')
@@ -84,9 +86,9 @@ export default defineComponent({
       try {
         const datasetId = propOr('', 'id', props.datasetInfo)
         const version = propOr('', 'version', props.datasetInfo)
-        const filePath = propOr('', 'path', props.file)
+        filePath.value = propOr('', 'path', props.file)
 
-        if (!filePath) {
+        if (!filePath.value) {
           throw new Error('No file path provided')
         }
 
@@ -95,7 +97,7 @@ export default defineComponent({
         }
 
         // Get presigned URL from download manifest
-        const url = await fetchManifestUrl(datasetId, version, filePath)
+        const url = await fetchManifestUrl(datasetId, version, filePath.value)
 
         if (!url) {
           throw new Error('Failed to get presigned URL for file')
@@ -117,6 +119,7 @@ export default defineComponent({
 
     return {
       presignedUrl,
+      filePath,
       isLoading,
       hasError,
       errorMessage,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@abi-software/simulationvuer": "3.0.15",
     "@element-plus/nuxt": "^1.0.10",
     "@nuxtjs/sitemap": "^5.1.4",
-    "@pennsieve-viz/micro-ct": "1.0.2",
+    "@pennsieve-viz/micro-ct": "1.0.71",
     "@pinia-plugin-persistedstate/nuxt": "^1.2.0",
     "@pinia/nuxt": "^0.5.1",
     "algoliasearch": "^4.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4579,10 +4579,10 @@
     marked "^15.0.7"
     ramda "^0.31.3"
 
-"@pennsieve-viz/micro-ct@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@pennsieve-viz/micro-ct/-/micro-ct-1.0.2.tgz#cae1943710bf8bacd36d249c56287fd124c936b3"
-  integrity sha512-G6tB0sY1VRe4pTdxBS7VJK1iAeE+ZFOu4aTwTZ1q/dhq2+ySNtyuBMd3I73vGyVVG30CObb4uLXzyS2vQxQxEw==
+"@pennsieve-viz/micro-ct@1.0.71":
+  version "1.0.71"
+  resolved "https://registry.yarnpkg.com/@pennsieve-viz/micro-ct/-/micro-ct-1.0.71.tgz#d168a1929796e8d108ec1b0ef38bd56e58414899"
+  integrity sha512-x1D247I39YBSzbZK1QJCoKyVnDxEGDoPyA0keqG2WDpD+NT6mWnoqWm89+xDX/6VNrMzpJfOsL1pAcpjXM9wmQ==
   dependencies:
     "@vivjs/extensions" "^0.18.0"
     "@vivjs/layers" "^0.18.0"


### PR DESCRIPTION
Upgrade @pennsieve-viz/micro-ct from 1.0.2 to 1.0.71 which adds support for interleaved RGB OME-TIFFs (single IFD with SamplesPerPixel=3), fixes WebGL texture size errors for large images, and adds in-memory + IndexedDB tile caching for faster reloads. Pass file path as cache-id prop to enable persistent tile caching across page refreshes.