### PR TITLE
Add OME-Zarr orthogonal viewer support

### DIFF
--- a/components/OrthogonalViewer/OrthogonalViewer.client.vue
+++ b/components/OrthogonalViewer/OrthogonalViewer.client.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="orthogonal-viewer-container">
+    <div class="viewer-wrapper">
+      <OrthogonalFrame
+        v-if="asset && asset.asset_url"
+        :source="asset.asset_url"
+        :embed-url="embedUrl"
+        :cloudfront="asset.cloudfront || null"
+        @ready="onReady"
+        @error="onError"
+      />
+    </div>
+    <generic-viewer-metadata
+      :datasetInfo="datasetInfo"
+      :file="file"
+      @download-file="$emit('download-file', $event)"
+    />
+  </div>
+</template>
+
+<script>
+import { defineComponent, defineAsyncComponent } from 'vue'
+import GenericViewerMetadata from '@/components/ViewersMetadata/GenericViewerMetadata.vue'
+import '@pennsieve-viz/core/style.css'
+
+// Lazy so @pennsieve-viz/core (which touches `document` at module load) only
+// evaluates in the browser, avoiding SSR ReferenceError.
+const OrthogonalFrame = defineAsyncComponent(() =>
+  import('@pennsieve-viz/core').then((m) => m.OrthogonalFrame)
+)
+
+export default defineComponent({
+  name: 'OrthogonalViewer',
+
+  components: {
+    GenericViewerMetadata,
+    OrthogonalFrame,
+  },
+
+  props: {
+    asset: {
+      type: Object,
+      default: () => ({}),
+    },
+    file: {
+      type: Object,
+      default: () => ({}),
+    },
+    datasetInfo: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+
+  emits: ['download-file'],
+
+  setup() {
+    const config = useRuntimeConfig()
+    const embedUrl = config.public.orthogonal_viewer_url
+
+    const onReady = () => {}
+    const onError = (message) => {
+      console.error('Orthogonal viewer error:', message)
+    }
+
+    return {
+      embedUrl,
+      onReady,
+      onError,
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+@import '@/assets/_viewer.scss';
+
+.orthogonal-viewer-container {
+  width: 100%;
+}
+
+.viewer-wrapper {
+  width: 100%;
+  min-height: 75vh;
+  height: 75vh;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #dcdfe6;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 1rem;
+
+  > * {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+}
+</style>

--- a/composables/useViewerAssets.js
+++ b/composables/useViewerAssets.js
@@ -1,0 +1,42 @@
+export const NEUROGLANCER_ASSET_TYPES = ['ome-zarr', 'neuroglancer-precomputed']
+
+export const useViewerAssets = () => {
+  const { $axios } = useNuxtApp()
+  const config = useRuntimeConfig()
+
+  async function fetchViewerAssets(packageId) {
+    if (!packageId) {
+      return { assets: [], cloudfront: null }
+    }
+
+    const url = `${config.public.PENNSIEVE_API_VERSION_2}/packages/discover/assets?package_id=${encodeURIComponent(packageId)}`
+
+    try {
+      const { data } = await $axios.get(url)
+      const cloudfront = data?.cloudfront || null
+
+      const seen = new Set()
+      const assets = (data?.assets || [])
+        .filter((a) => {
+          if (!NEUROGLANCER_ASSET_TYPES.includes(a.asset_type)) return false
+          if (a.status !== 'ready') return false
+          if (seen.has(a.asset_url)) return false
+          seen.add(a.asset_url)
+          return true
+        })
+        .map((a) => ({ ...a, cloudfront }))
+
+      return { assets, cloudfront }
+    } catch (error) {
+      // 404 means the package has no viewer assets — expected case, not an error.
+      if (error?.response?.status !== 404) {
+        console.error('Error fetching viewer assets:', error)
+      }
+      return { assets: [], cloudfront: null }
+    }
+  }
+
+  return {
+    fetchViewerAssets,
+  }
+}

--- a/composables/useViewerAssets.js
+++ b/composables/useViewerAssets.js
@@ -9,7 +9,7 @@ export const useViewerAssets = () => {
       return { assets: [], cloudfront: null }
     }
 
-    const url = `${config.public.PENNSIEVE_API_VERSION_2}/packages/discover/assets?package_id=${encodeURIComponent(packageId)}`
+    const url = `${config.public.PENNSIEVE_DISCOVER_API_HOST_V2}/packages/discover/assets?package_id=${encodeURIComponent(packageId)}`
 
     try {
       const { data } = await $axios.get(url)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -181,6 +181,7 @@ export default defineNuxtConfig({
       GITHUB_REPO: process.env.GITHUB_REPO || 'sparc-app-2',
       LOGIN_API_URL: process.env.LOGIN_API_URL || 'https://api.pennsieve.net',
       PENNSIEVE_API_VERSION_2: process.env.PENNSIEVE_API_VERSION_2 || 'https://api2.pennsieve.net',
+      orthogonal_viewer_url: process.env.PENNSIEVE_ORTHOGONAL_VIEWER_URL || 'https://orthogonal-viewer.pennsieve.net',
       SHOW_HIERARCHAL_FACETS: process.env.SHOW_HIERARCHAL_FACETS || 'false',
       SHOW_SDS_VIEWER: process.env.SHOW_SDS_VIEWER || 'false',
       SHOW_TIMESERIES_VIEWER: process.env.SHOW_TIMESERIES_VIEWER || 'false',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -131,6 +131,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       discover_api_host: process.env.PENNSIEVE_DISCOVER_API_HOST || 'https://api.pennsieve.io/discover',
+      PENNSIEVE_DISCOVER_API_HOST_V2: process.env.PENNSIEVE_DISCOVER_API_HOST_V2 || 'https://api2.pennsieve.io',
       zipit_api_host: process.env.ZIPIT_API_HOST || 'https://api.pennsieve.io/zipit/discover',
       CTF_SPACE_ID: process.env.CTF_SPACE_ID,
       CTF_CDA_ACCESS_TOKEN: process.env.CTF_CDA_ACCESS_TOKEN,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@abi-software/simulationvuer": "3.0.16",
     "@element-plus/nuxt": "^1.0.10",
     "@nuxtjs/sitemap": "^5.1.4",
+    "@pennsieve-viz/core": "0.3.1",
     "@pennsieve-viz/micro-ct": "1.0.71",
     "@pinia-plugin-persistedstate/nuxt": "^1.2.0",
     "@pinia/nuxt": "^0.5.1",

--- a/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
+++ b/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
@@ -7,12 +7,22 @@
         <form ref="zipForm" method="POST" :action="zipitUrl">
           <input v-model="zipData" type="hidden" name="data" />
         </form>
-        <span class="help-link" v-if="hasViewer && (activeTabId in helpers)">
-          <a :href="`https://docs.sparc.science/docs/${helpers[activeTabId].link}`" target="_blank">
-            Find out more about the {{ helpers[activeTabId].name }}
+        <span class="help-link" v-if="hasViewer && (activeHelperId in helpers)">
+          <a :href="`https://docs.sparc.science/docs/${helpers[activeHelperId].link}`" target="_blank">
+            Find out more about the {{ helpers[activeHelperId].name }}
           </a>
         </span>
         <content-tab-card v-if="hasViewer" class="mt-24" :tabs="tabs" :active-tab-id="activeTabId">
+          <template v-if="hasOrthogonalViewer">
+            <orthogonal-viewer
+              v-for="(asset, idx) in viewerAssets"
+              :key="asset.asset_url"
+              v-show="activeTabId === `orthogonalViewer-${idx}`"
+              :asset="asset"
+              :datasetInfo="datasetInfo"
+              :file="file"
+              @download-file="executeDownload" />
+          </template>
           <simulation-viewer v-if="hasSimulationViewer" v-show="activeTabId === 'simulationViewer'"
             :apiLocation="apiLocation" :datasetInfo="datasetInfo" :file="file" @download-file="executeDownload" />
           <plot-viewer v-if="hasPlotViewer" v-show="activeTabId === 'plotViewer'" :plotInfo="plotInfo"
@@ -43,6 +53,7 @@ import scicrunch from '@/services/scicrunch'
 import PlotViewer from '@/components/PlotViewer/PlotViewer.vue'
 import VideoViewer from '@/components/VideoViewer/VideoViewer'
 import OmeViewerComponent from '@/components/OmeViewer/OmeViewer.client.vue'
+import OrthogonalViewer from '@/components/OrthogonalViewer/OrthogonalViewer.client.vue'
 import FileViewerMetadata from '@/components/ViewersMetadata/FileViewerMetadata.vue'
 import FormatDate from '@/mixins/format-date'
 import FetchPennsieveFile from '@/mixins/fetch-pennsieve-file'
@@ -60,6 +71,7 @@ export default {
     PlotViewer,
     VideoViewer,
     OmeViewerComponent,
+    OrthogonalViewer,
     FileViewerMetadata,
     Gallery
   },
@@ -168,7 +180,19 @@ export default {
     }
     const hasOmeViewer = isOmeTiffFile(file.name)
 
-    let activeTabId = hasOmeViewer ? 'omeViewer' :
+    // Fetch orthogonal viewer assets (ome-zarr / neuroglancer-precomputed) for this package.
+    // The api2 endpoint returns ready zarr assets regardless of source file type
+    // (nii.gz and ome.tiff packages are server-side converted to zarr).
+    let viewerAssets = []
+    if (sourcePackageId) {
+      const { fetchViewerAssets } = useViewerAssets()
+      const result = await fetchViewerAssets(sourcePackageId)
+      viewerAssets = result.assets
+    }
+    const hasOrthogonalViewer = viewerAssets.length > 0
+
+    let activeTabId = hasOrthogonalViewer ? 'orthogonalViewer-0' :
+      hasOmeViewer ? 'omeViewer' :
       hasTimeseriesViewer ? 'timeseriesViewer' :
       hasSimulationViewer ? 'simulationViewer' :
       hasPlotViewer ? 'plotViewer' :
@@ -211,6 +235,8 @@ export default {
       hasSimulationViewer,
       hasVideoViewer,
       hasOmeViewer,
+      hasOrthogonalViewer,
+      viewerAssets,
       sourcePackageId,
       signedUrl,
       packageType,
@@ -240,6 +266,10 @@ export default {
         omeViewer: {
           name: 'OME-TIFF Viewer',
           link: 'ome-tiff-viewer'
+        },
+        orthogonalViewer: {
+          name: 'Orthogonal Viewer',
+          link: 'orthogonal-viewer'
         }
       }
     }
@@ -248,7 +278,16 @@ export default {
   computed: {
     hasViewer: function() {
       return this.hasSimulationViewer ||
-        this.hasPlotViewer || this.hasVideoViewer || this.hasOmeViewer
+        this.hasPlotViewer || this.hasVideoViewer || this.hasOmeViewer ||
+        this.hasOrthogonalViewer
+    },
+    activeHelperId: function() {
+      // Orthogonal tab ids are suffixed per asset (orthogonalViewer-0); map back
+      // to the single helper entry.
+      if (typeof this.activeTabId === 'string' && this.activeTabId.startsWith('orthogonalViewer')) {
+        return 'orthogonalViewer'
+      }
+      return this.activeTabId
     },
     datasetId: function() {
       return this.$route.params.datasetId
@@ -348,6 +387,21 @@ export default {
           })
         } else {
           this.tabs = this.tabs.filter(tab => tab.id !== 'omeViewer')
+        }
+      },
+      immediate: true
+    },
+    hasOrthogonalViewer: {
+      handler: function(hasViewer) {
+        // Remove any prior orthogonal tabs, then push one per ready asset.
+        this.tabs = this.tabs.filter(tab => !tab.id.startsWith('orthogonalViewer'))
+        if (hasViewer) {
+          const orthogonalTabs = this.viewerAssets.map((asset, idx) => ({
+            label: asset.name || `Orthogonal Viewer ${idx + 1}`,
+            id: `orthogonalViewer-${idx}`
+          }))
+          // Prepend so orthogonal tabs appear first in the tab order.
+          this.tabs = [...orthogonalTabs, ...this.tabs]
         }
       },
       immediate: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,6 +3533,18 @@
     jszip "^3.1.5"
     md5 "^2.3.0"
 
+"@lukeed/csprng@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
+  integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
+
+"@lukeed/uuid@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@lukeed/uuid/-/uuid-2.0.1.tgz#4f6c34259ee0982a455e1797d56ac27bb040fd74"
+  integrity sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==
+  dependencies:
+    "@lukeed/csprng" "^1.1.0"
+
 "@luma.gl/constants@9.1.7", "@luma.gl/constants@^9.1.5", "@luma.gl/constants@~9.1.9":
   version "9.1.7"
   resolved "https://registry.yarnpkg.com/@luma.gl/constants/-/constants-9.1.7.tgz#cce355d54cda7027d7e182c9b67edb792b2f4003"
@@ -3830,6 +3842,21 @@
   dependencies:
     "@netlify/node-cookies" "^0.1.0"
     urlpattern-polyfill "8.0.2"
+
+"@niivue/niivue@^0.68.1":
+  version "0.68.2"
+  resolved "https://registry.yarnpkg.com/@niivue/niivue/-/niivue-0.68.2.tgz#31f6dae94d64c5d50c1c8121847fffaa978f10b1"
+  integrity sha512-9CKGb40CTYpw5TptvPsY9VaAiGRY+cK7qHL5zAYV/q9rWeKzcHeUumtVHxDI0mVdCiuMoHGJIEZPnHICWcCDDw==
+  dependencies:
+    "@lukeed/uuid" "^2.0.1"
+    "@ungap/structured-clone" "^1.2.0"
+    array-equal "^1.0.2"
+    fflate "^0.8.2"
+    gl-matrix "^3.4.3"
+    nifti-reader-js "^0.8.0"
+    zarrita "^0.5.0"
+  optionalDependencies:
+    "@rollup/rollup-linux-x64-gnu" "^4.18.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -4579,6 +4606,20 @@
     marked "^15.0.7"
     ramda "^0.31.3"
 
+"@pennsieve-viz/core@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@pennsieve-viz/core/-/core-0.3.1.tgz#9a16f8dec36aa177a5c4a1aa91ca0a10c4675ccc"
+  integrity sha512-qJ3VMZb84frnXa+kM1VWJwNZi1tu+2GhpfAKzrLiKYEqfct3uM8CHLqtFxLifcTYrpUMwM8mHczArv9cZ62jeg==
+  dependencies:
+    "@element-plus/icons-vue" "^2.3.1"
+    "@niivue/niivue" "^0.68.1"
+    d3 "^7.9.0"
+    dompurify "^3.2.6"
+    element-plus "^2.3.0"
+    hyparquet "^1.12.1"
+    marked "^15.0.7"
+    ramda "^0.31.3"
+
 "@pennsieve-viz/micro-ct@1.0.71":
   version "1.0.71"
   resolved "https://registry.yarnpkg.com/@pennsieve-viz/micro-ct/-/micro-ct-1.0.71.tgz#d168a1929796e8d108ec1b0ef38bd56e58414899"
@@ -4917,6 +4958,11 @@
   version "4.9.6"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.6.tgz#5ac5d068ce0726bd0a96ca260d5bd93721c0cb98"
   integrity sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==
+
+"@rollup/rollup-linux-x64-gnu@^4.18.1":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz#6aa8302fa45fd3cbbc510ccd223c9c37bf67e53f"
+  integrity sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==
 
 "@rollup/rollup-linux-x64-musl@4.9.6":
   version "4.9.6"
@@ -6031,6 +6077,14 @@
     defu "^6.1.2"
     sirv "^2.0.3"
 
+"@zarrita/storage@^0.1.3":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@zarrita/storage/-/storage-0.1.4.tgz#05d7d1d43fc0163d22a17356b619ffeb1ed223d7"
+  integrity sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==
+  dependencies:
+    reference-spec-reader "^0.2.0"
+    unzipit "1.4.3"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -6287,6 +6341,11 @@ array-buffer-byte-length@^1.0.0:
   dependencies:
     call-bind "^1.0.2"
     is-array-buffer "^3.0.1"
+
+array-equal@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.2.tgz#a8572e64e822358271250b9156d20d96ef5dec04"
+  integrity sha512-gUHx76KtnhEgB3HOuFYiCm3FIdEs6ocM2asHvNTkfu/Y09qQVrrVVaOKENmS2KkSaGoxgXNqC+ZVtR/n0MOkSA==
 
 array-find-index@^1.0.2:
   version "1.0.2"
@@ -9576,6 +9635,11 @@ fflate@0.7.4:
   resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.7.4.tgz#61587e5d958fdabb5a9368a302c25363f4f69f50"
   integrity sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==
 
+fflate@^0.8.0, fflate@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
 figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -12407,6 +12471,13 @@ next-tick@^1.1.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
+nifti-reader-js@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/nifti-reader-js/-/nifti-reader-js-0.8.0.tgz#3aa2109e0139d89e625fdaba6d9ada1bd59a903a"
+  integrity sha512-iO1iIhQDfKniy+l/86HfOPte7So+SxBmBiMSiUB2VXU7z4hSewMTlE3h0fCgfzfXvMUa+ilzLTJ2ZHmtFw6EWw==
+  dependencies:
+    fflate "^0.8.2"
+
 nitropack@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/nitropack/-/nitropack-2.8.1.tgz#9132cf8c01417c32ee45338e1d3fd00cac6219f8"
@@ -12729,6 +12800,13 @@ numcodecs@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/numcodecs/-/numcodecs-0.2.2.tgz#33d8b72e7223f3c80d67b9007720b9b54c62c240"
   integrity sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ==
+
+numcodecs@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/numcodecs/-/numcodecs-0.3.2.tgz#09887cfc2a3ae1c59a495c01a7f0528118d85dcd"
+  integrity sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==
+  dependencies:
+    fflate "^0.8.0"
 
 nuxi@^3.10.0:
   version "3.10.0"
@@ -14334,6 +14412,11 @@ redis-parser@^3.0.0:
   integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
   dependencies:
     redis-errors "^1.0.0"
+
+reference-spec-reader@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz#52bd79614dde68e68f05c97a05ae04ff20acd7ec"
+  integrity sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"
@@ -16276,6 +16359,13 @@ untyped@^1.4.2:
     mri "^1.2.0"
     scule "^1.2.0"
 
+unzipit@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/unzipit/-/unzipit-1.4.3.tgz#738298a6b235892bf7ce7db82cff813d4ca664ac"
+  integrity sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==
+  dependencies:
+    uzip-module "^1.0.2"
+
 update-browserslist-db@^1.0.13:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz#3c5e4f5c083661bd38ef64b6328c26ed6c8248c4"
@@ -16374,6 +16464,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uzip-module@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/uzip-module/-/uzip-module-1.0.3.tgz#6bbabe2a3efea5d5a4a47479f523a571de3427ce"
+  integrity sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==
 
 v-lazy-show@^0.2.4:
   version "0.2.4"
@@ -16967,6 +17062,14 @@ zarr@^0.6.2:
   dependencies:
     numcodecs "^0.2.2"
     p-queue "^7.1.0"
+
+zarrita@^0.5.0:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/zarrita/-/zarrita-0.5.4.tgz#b64a323c6f6c33e7f3cf741f70d5f48b31a7fb5a"
+  integrity sha512-i88iN2+HqIQ+uiCEWLfhjbYNXAJD7IrM4h3lFwFclfqEOOhxp10amRWtqmgN5jbuy3+h0LwdyLVVzk4y9rTLgg==
+  dependencies:
+    "@zarrita/storage" "^0.1.3"
+    numcodecs "^0.3.2"
 
 zen-observable-ts@0.8.19:
   version "0.8.19"


### PR DESCRIPTION
                                                                                        
-  Renders the hosted neuroglancer-based OrthogonalFrame from @pennsieve-viz/core on the file detail page (/datasets/file/<id>/<version>) for packages with ready ome-zarr /     
-   neuroglancer-precomputed assets — covers .nii.gz and .ome.tiff packages too since the server returns the converted zarr.                                                      
-   New useViewerAssets composable hits GET                                               
-   {PENNSIEVE_API_VERSION_2}/packages/discover/assets?package_id=<sourcePackageId>, filters to status: 'ready', dedupes by asset_url, and attaches the response cloudfront credentials to each asset. Treats 404 as "no assets" (silent, not an error).            
-   New components/OrthogonalViewer/OrthogonalViewer.client.vue wraps OrthogonalFrame per asset (75vh) with GenericViewerMetadata below, matching the existing OmeViewer.client.vue pattern. Dynamic-imports @pennsieve-viz/core to avoid SSR document is not defined.                                                                         
-    Integrates into the existing ContentTabCard on the file detail page: prepends one tab per ready asset (label = asset.name), so neuroglancer tabs take priority in the tab order and become the default activeTabId when present.
-   Passes CloudFront { policy, signature, key_pair_id } through to the iframe via postMessage (service-worker-signed requests — no cookies set).                          
-    Adds @pennsieve-viz/core@0.3.1 dependency and orthogonal_viewer_url runtime config (env override: PENNSIEVE_ORTHOGONAL_VIEWER_URL, default https://orthogonal-viewer.pennsieve.net).
-   Adds an Orthogonal Viewer entry to the helpers doc-link map (docs.sparc.science/docs/orthogonal-viewer) — note: that docs page may need to be created separately.