### PR TITLE
Add debug logging to OrthogonalViewer CloudFront prop

### DIFF
--- a/components/OrthogonalViewer/OrthogonalViewer.client.vue
+++ b/components/OrthogonalViewer/OrthogonalViewer.client.vue
@@ -54,11 +54,21 @@ export default defineComponent({
 
   emits: ['download-file'],
 
-  setup() {
+  setup(props) {
     const config = useRuntimeConfig()
     const embedUrl = config.public.orthogonal_viewer_url
 
-    const onReady = () => {}
+    console.log('[OrthogonalViewer] embedUrl:', embedUrl)
+    console.log('[OrthogonalViewer] asset.asset_url:', props.asset?.asset_url)
+    console.log('[OrthogonalViewer] asset.cloudfront:', props.asset?.cloudfront ? {
+      policy: props.asset.cloudfront.policy?.substring(0, 20) + '...',
+      signature: props.asset.cloudfront.signature?.substring(0, 20) + '...',
+      key_pair_id: props.asset.cloudfront.key_pair_id,
+    } : null)
+
+    const onReady = () => {
+      console.log('[OrthogonalViewer] iframe ready')
+    }
     const onError = (message) => {
       console.error('Orthogonal viewer error:', message)
     }


### PR DESCRIPTION
Logs asset URL and cloudfront credential values passed to OrthogonalFrame to diagnose SW signing issue.