### PR TITLE
Lazy-load @pennsieve-viz/core CSS to avoid SSR resolution

### DIFF
--- a/components/OrthogonalViewer/OrthogonalViewer.client.vue
+++ b/components/OrthogonalViewer/OrthogonalViewer.client.vue
@@ -19,9 +19,8 @@
 </template>
 
 <script>
-import { defineComponent, defineAsyncComponent } from 'vue'
+import { defineComponent, defineAsyncComponent, onMounted } from 'vue'
 import GenericViewerMetadata from '@/components/ViewersMetadata/GenericViewerMetadata.vue'
-import '@pennsieve-viz/core/style.css'
 
 // Lazy so @pennsieve-viz/core (which touches `document` at module load) only
 // evaluates in the browser, avoiding SSR ReferenceError.
@@ -55,6 +54,8 @@ export default defineComponent({
   emits: ['download-file'],
 
   setup(props) {
+    onMounted(() => import('@pennsieve-viz/core/style.css'))
+
     const config = useRuntimeConfig()
     const embedUrl = config.public.orthogonal_viewer_url
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -275,11 +275,6 @@ export default defineNuxtConfig({
     blockNonSeoBots: true,
     sitemap: `${process.env.ROOT_URL}/sitemap.xml`
   },
-  nitro: {
-    externals: {
-      inline: ['dayjs']
-    }
-  },
   vue: {
     compilerOptions: {
       isCustomElement: (tag: string) => [


### PR DESCRIPTION
The top-level CSS import forced Vite to resolve @pennsieve-viz/core during SSR, pulling element-plus/dayjs into the server bundle. Move it to a dynamic import inside onMounted so it only loads client-side.