### PR TITLE
Update map-viewer to 1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "semver": "^7.7.3"
   },
   "dependencies": {
-    "@abi-software/mapintegratedvuer": "1.18.0",
+    "@abi-software/mapintegratedvuer": "1.18.1",
     "@abi-software/plotcomponents": "^0.2.4",
     "@abi-software/plotdatahelpers": "^0.1.2",
     "@abi-software/simulationvuer": "3.0.16",
@@ -69,7 +69,7 @@
     "string-width": "4.2.3",
     "mlly": "1.4.0",
     "vue": "3.4.21",
-    "@abi-software/flatmapvuer": "1.13.2",
+    "@abi-software/flatmapvuer": "1.13.3",
     "@deck.gl/core": "9.1.8",
     "@deck.gl/extensions": "9.1.8",
     "@deck.gl/geo-layers": "9.1.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "semver": "^7.7.3"
   },
   "dependencies": {
-    "@abi-software/mapintegratedvuer": "1.17.4",
+    "@abi-software/mapintegratedvuer": "1.18.0",
     "@abi-software/plotcomponents": "^0.2.4",
     "@abi-software/plotdatahelpers": "^0.1.2",
     "@abi-software/simulationvuer": "3.0.16",
@@ -69,7 +69,7 @@
     "string-width": "4.2.3",
     "mlly": "1.4.0",
     "vue": "3.4.21",
-    "@abi-software/flatmapvuer": "1.13.1",
+    "@abi-software/flatmapvuer": "1.13.2",
     "@deck.gl/core": "9.1.8",
     "@deck.gl/extensions": "9.1.8",
     "@deck.gl/geo-layers": "9.1.8",

--- a/tests/cypress/e2e/mapsviewer.cy.js
+++ b/tests/cypress/e2e/mapsviewer.cy.js
@@ -98,7 +98,7 @@ mapTypes.forEach((map) => {
         // Close new opened dialog
         cy.get('.header > .icon-group > .map-icon:visible').first().click()
         cy.contains('Vertical split').click()
-        cy.get('.pane-1 > .content-container > .toolbar > .el-row > .map-icon').click({force: true})
+        cy.get('.pane-1 > .content-container > .toolbar > .toolbar-flex-container > .map-icon').click({force: true})
       })
 
       it('In-display search', function () {
@@ -410,7 +410,7 @@ mapTypes.forEach((map) => {
         // Close new opened dialog
         cy.get('.header > .icon-group > .map-icon:visible').first().click()
         cy.contains('Vertical split').click()
-        cy.get('.pane-1 > .content-container > .toolbar > .el-row > .map-icon').click({force: true})
+        cy.get('.pane-1 > .content-container > .toolbar > .toolbar-flex-container > .map-icon').click({force: true})
       })
     }/* else if (map === 'fc') {
       it('Map is loaded', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,12 +7,12 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@abi-software/flatmapvuer@1.13.1":
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.13.1.tgz#506beebc2f9d0e35c0a44a8eda53fd0c0944eefb"
-  integrity sha512-pyeG8i3owWLYOYlRBR1f22QRd7VTGT38fPeAJIciP0y9l9mPukIPnwlqA5BRoR29J7HkMqcqodfHfR/FRwOJPw==
+"@abi-software/flatmapvuer@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.13.2.tgz#c5e86658349e79edb0f621f537b91cc3213c8286"
+  integrity sha512-6k31x6sEz+eOrBnGRidflkRY4P1BSacqSGE6pJgSddLmPY4RXhPoFchZ30ZbEdR3bAAhYZzvOQe+535F2rCAaw==
   dependencies:
-    "@abi-software/map-utilities" "1.8.1"
+    "@abi-software/map-utilities" "1.8.2"
     "@abi-software/sparc-annotation" "0.3.2"
     "@abi-software/svg-sprite" "1.0.3"
     "@element-plus/icons-vue" "^2.3.1"
@@ -36,13 +36,13 @@
     unplugin-vue-components "^0.26.0"
     vue "^3.4.21"
 
-"@abi-software/map-side-bar@2.14.2":
-  version "2.14.2"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-2.14.2.tgz#648de9b15f182a57b15e333901dc6a3b044b3a7f"
-  integrity sha512-xmEJGY9FzwwbChYDkAETincPDfTAw4wukGK/Igur0jsy0Y5u0WiQ7B5WrkhhSUxhNM9cdLkhr6oonK43jAU7mw==
+"@abi-software/map-side-bar@2.14.3":
+  version "2.14.3"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-2.14.3.tgz#869dac9cecd7623906a10f224b9add0829c23cee"
+  integrity sha512-8mNOTmEe4aKdOdPF2CWj3ZFi4bQ5FRrB3myT2q3lmdIanVNvV3suu8XTfg2SnBuMmmLzCByOxfTGaUMQPFKjaA==
   dependencies:
     "@abi-software/gallery" "1.3.0"
-    "@abi-software/map-utilities" "1.8.1"
+    "@abi-software/map-utilities" "1.8.2"
     "@abi-software/svg-sprite" "^1.0.2"
     "@element-plus/icons-vue" "^2.3.1"
     algoliasearch "^4.10.5"
@@ -54,10 +54,10 @@
     vue "^3.4.21"
     xss "^1.0.14"
 
-"@abi-software/map-utilities@1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-utilities/-/map-utilities-1.8.1.tgz#9f7dcae1ba19fdbc6df944d5fb138014171fbb23"
-  integrity sha512-yinECWuKKq75me+JQSjatw8zlPrK7vK0apwDp4lPh+GnfIw271q1EJ22veJDZuQJKd6U+wjjolrAIPLAcXVBQg==
+"@abi-software/map-utilities@1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-utilities/-/map-utilities-1.8.2.tgz#a03aaeb1d2b5e57630ac3671266a780db3d51341"
+  integrity sha512-8ASoKfYmU5NmYrAlu8msgaq99cUgNn+hIPLHwloJGF12zg9A44p5IPYM7+rPZEDI8762TAd2STNakQAo7rcl5Q==
   dependencies:
     "@abi-software/svg-sprite" "^1.0.1"
     "@element-plus/icons-vue" "^2.3.1"
@@ -67,16 +67,16 @@
     mitt "^3.0.1"
     vue "^3.4.21"
 
-"@abi-software/mapintegratedvuer@1.17.4":
-  version "1.17.4"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.17.4.tgz#bb899244e757d86a102534339e35806a6f32ba73"
-  integrity sha512-05lFXm5AjSOdmJE5u+rM1awP+su0bky0atZOgjrL1kOMbHr57iXgjvzMr2FRBJFwQ8SzygQ/UgErNcXfY9hVRA==
+"@abi-software/mapintegratedvuer@1.18.0":
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.18.0.tgz#7251e92904938292dfa04068483d5b28813a74c4"
+  integrity sha512-1xNtiwCzCJ9KCCU9JcajUnH9+oTJHzQBt4FGn+zq16i6M8pMJkbabbMVPKgSEMW3rR3drr+TPRTYOdrNnQMIqQ==
   dependencies:
-    "@abi-software/flatmapvuer" "1.13.1"
-    "@abi-software/map-side-bar" "2.14.2"
-    "@abi-software/map-utilities" "1.8.1"
+    "@abi-software/flatmapvuer" "1.13.2"
+    "@abi-software/map-side-bar" "2.14.3"
+    "@abi-software/map-utilities" "1.8.2"
     "@abi-software/plotvuer" "1.0.7"
-    "@abi-software/scaffoldvuer" "1.15.4"
+    "@abi-software/scaffoldvuer" "1.15.5"
     "@abi-software/simulationvuer" "3.0.16"
     "@abi-software/sparc-annotation" "0.3.2"
     "@abi-software/svg-sprite" "1.0.4"
@@ -126,12 +126,12 @@
     vue-draggable-resizable "^2.2.0"
     vue-router "^4.2.5"
 
-"@abi-software/scaffoldvuer@1.15.4":
-  version "1.15.4"
-  resolved "https://registry.yarnpkg.com/@abi-software/scaffoldvuer/-/scaffoldvuer-1.15.4.tgz#dff9456553a700b58169637ef7d04a9406301404"
-  integrity sha512-w4M9m7omf5Fpx5Sr+4oaYjvBX+tnkwPfkE9bZL9O0pu7eWutLTYk/hdTkXwsFO0QQUgEDVd/Esp8Esve9xi3Yg==
+"@abi-software/scaffoldvuer@1.15.5":
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/@abi-software/scaffoldvuer/-/scaffoldvuer-1.15.5.tgz#bffc3577bf12392d001289125ece2d92616f414d"
+  integrity sha512-w51YSdb6QxXZrhFvmojTNPvHUP9RNkB4NqEsr69L0/kYuJnSN+hQ6WUfo2Zs+2rYmZ0ELw0YfRIsJyFuoqSgrw==
   dependencies:
-    "@abi-software/map-utilities" "1.8.1"
+    "@abi-software/map-utilities" "1.8.2"
     "@abi-software/sparc-annotation" "^0.3.2"
     "@abi-software/svg-sprite" "1.0.3"
     "@element-plus/icons-vue" "^2.3.1"
@@ -143,7 +143,7 @@
     unplugin-vue-components "^0.26.0"
     vue "^3.4.21"
     vue-router "^4.2.5"
-    zincjs "1.18.8"
+    zincjs "1.18.9"
 
 "@abi-software/simulationvuer@3.0.16":
   version "3.0.16"
@@ -17099,10 +17099,10 @@ zhead@^2.2.4:
   resolved "https://registry.yarnpkg.com/zhead/-/zhead-2.2.4.tgz#87cd1e2c3d2f465fa9f43b8db23f9716dfe6bed7"
   integrity sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==
 
-zincjs@1.18.8:
-  version "1.18.8"
-  resolved "https://registry.yarnpkg.com/zincjs/-/zincjs-1.18.8.tgz#6b80bd55c451ee6d1e7546f91e8936ac6c570e15"
-  integrity sha512-tmB50i1fx2x1DSs+Mr3xk+ZvEjOHIDodlv9R9hAzdZpNxmh64ORWmx+RHRz80dx6kjKpAAsnezBukFucGyvUAQ==
+zincjs@1.18.9:
+  version "1.18.9"
+  resolved "https://registry.yarnpkg.com/zincjs/-/zincjs-1.18.9.tgz#333d2e8ff73f7af2c75bd97a1979e74ae15d686a"
+  integrity sha512-Zxc9B+xeedA9BuwMWGA0667A0qNTAiySVaKJi2AvzM6zKqjtdaqDhUH6xk+THdJPt1eglagQZ5fT/tmZZheKCg==
   dependencies:
     css-element-queries "^1.2.2"
     lodash "^4.17.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@abi-software/flatmapvuer@1.13.2":
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.13.2.tgz#c5e86658349e79edb0f621f537b91cc3213c8286"
-  integrity sha512-6k31x6sEz+eOrBnGRidflkRY4P1BSacqSGE6pJgSddLmPY4RXhPoFchZ30ZbEdR3bAAhYZzvOQe+535F2rCAaw==
+"@abi-software/flatmapvuer@1.13.3":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@abi-software/flatmapvuer/-/flatmapvuer-1.13.3.tgz#e985ecf79cbda7fe8e1db35fa9269f2299f8c290"
+  integrity sha512-f0rGTz9sc4spGZeNKicpXOScOYA85y+ONDcGd4bsjgAP3cm9gTdXUNPacEwsesZUuxsTPasd/ODmRcmDoU3JwA==
   dependencies:
     "@abi-software/map-utilities" "1.8.2"
     "@abi-software/sparc-annotation" "0.3.2"
@@ -36,10 +36,10 @@
     unplugin-vue-components "^0.26.0"
     vue "^3.4.21"
 
-"@abi-software/map-side-bar@2.14.3":
-  version "2.14.3"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-2.14.3.tgz#869dac9cecd7623906a10f224b9add0829c23cee"
-  integrity sha512-8mNOTmEe4aKdOdPF2CWj3ZFi4bQ5FRrB3myT2q3lmdIanVNvV3suu8XTfg2SnBuMmmLzCByOxfTGaUMQPFKjaA==
+"@abi-software/map-side-bar@2.14.4":
+  version "2.14.4"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-2.14.4.tgz#037af87f027f5bbf19962ad715ecc33ab763ce8b"
+  integrity sha512-oLnmxuDbzmMTC9ZsAfqfcKJjKigcKNjuagO+DodrGv1EPtmhjOkD5aBxZNdfC9JxWkTOxriNFXyaJBuUXQDMiQ==
   dependencies:
     "@abi-software/gallery" "1.3.0"
     "@abi-software/map-utilities" "1.8.2"
@@ -67,13 +67,13 @@
     mitt "^3.0.1"
     vue "^3.4.21"
 
-"@abi-software/mapintegratedvuer@1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.18.0.tgz#7251e92904938292dfa04068483d5b28813a74c4"
-  integrity sha512-1xNtiwCzCJ9KCCU9JcajUnH9+oTJHzQBt4FGn+zq16i6M8pMJkbabbMVPKgSEMW3rR3drr+TPRTYOdrNnQMIqQ==
+"@abi-software/mapintegratedvuer@1.18.1":
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.18.1.tgz#d0088a5a78df34e1c4525bf4be768aa783395c69"
+  integrity sha512-U/ldU+mfXzrwni7XYFV85QnDGT13xKAbYJrBPWG2ltnMWQMaUbbtp+gXamm9JTU1IUuLOjcWL4Kut1e+68pYPg==
   dependencies:
-    "@abi-software/flatmapvuer" "1.13.2"
-    "@abi-software/map-side-bar" "2.14.3"
+    "@abi-software/flatmapvuer" "1.13.3"
+    "@abi-software/map-side-bar" "2.14.4"
     "@abi-software/map-utilities" "1.8.2"
     "@abi-software/plotvuer" "1.0.7"
     "@abi-software/scaffoldvuer" "1.15.5"


### PR DESCRIPTION
New features:

- A new chip has been added to bring user to the source dataset / connectivity information in map-viewer. The new UI is located next the pane's title

Improvements:

-  A new chip Notes has replaced the Alert tooltip in connectivitiy information. Clicking on Notes will bring the user to the new Notes section in connectivity information.

This can be tested on https://alan-wu-sparc-app.herokuapp.com/