### PR TITLE
Reinstate image gallery

### DIFF
--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -433,33 +433,6 @@ export default {
                   link: linkUrl
                 })
               }
-            } else {
-              let title = f.uberonid ? f.uberonid : null
-              if (f.organ) {
-                title = `View ${f.organ}`
-              }
-              let linkUrl = `${baseRoute}maps?type=flatmap&dataset_version=${datasetVersion}&dataset_id=${datasetId}&taxo=${f.taxo}`
-              if (f.uberonid) linkUrl = linkUrl + `&uberonid=${f.uberonid}`
-              if (f.species) linkUrl = linkUrl + `&for_species=${f.species}`
-              const item = {
-                id: f.uberonid,
-                title: title,
-                type: `${this.capitalize(
-                  f.species && f.species === flatmaps.speciesMap[f.taxo] ? f.species : 'generic'
-                )} flatmap`,
-                thumbnail: null,
-                link: linkUrl
-              }
-
-              this.scaleThumbnailImage(
-                item,
-                {
-                  mimetype: 'image/png',
-                  data: this.flatmapImg[flatmaps.speciesMap[f.taxo]]
-                },
-                true
-              )
-              items.push(item)
             }
           });
         }

--- a/components/ImagesGallery/ImagesGallery.vue
+++ b/components/ImagesGallery/ImagesGallery.vue
@@ -20,7 +20,7 @@
       </div>
       <gallery class="file-viewer-gallery" galleryItemType="fileViewer" :items="galleryItems" :cardWidth="13.8" />
     </div>
-    <div v-else>This dataset does not contain gallery items</div>
+    <div v-else>This dataset does not contain any gallery item.</div>
   </div>
 </template>
 

--- a/pages/datasets/[datasetId].vue
+++ b/pages/datasets/[datasetId].vue
@@ -76,6 +76,7 @@
                 <citation-details class="body1" v-show="activeTabId === 'cite'" :doi-value="datasetInfo.doi" />
                 <dataset-files-info class="body1" v-if="hasFiles" v-show="activeTabId === 'files'" />
                 <source-code-info class="body1" v-if="hasSourceCode" v-show="activeTabId === 'source'" :repoLink="sourceCodeLink" :osparcLink="osparcLink" />
+                <images-gallery class="body1" :markdown="markdown.markdownTop" v-show="activeTabId === 'images'" />
                 <div class="body1" v-show="activeTabId === 'metrics'">
                   <div v-if="hasCitations">
                     <dataset-references :primary-publications="primaryPublications" :associated-publications="associatedPublications" :citing-publications="citingPublications" />
@@ -93,7 +94,6 @@
       </div>
       <dataset-version-message v-if="!isLatestVersion" :current-version="datasetInfo.version"
         :dataset-details="datasetInfo" />
-    
   </div>
 </template>
 
@@ -115,6 +115,7 @@ import DatasetAboutInfo from '@/components/DatasetDetails/DatasetAboutInfo.vue'
 import CitationDetails from '@/components/CitationDetails/CitationDetails.vue'
 import DatasetFilesInfo from '@/components/DatasetDetails/DatasetFilesInfo.vue'
 import SourceCodeInfo from '@/components/DatasetDetails/SourceCodeInfo.vue'
+import ImagesGallery from '@/components/ImagesGallery/ImagesGallery.vue'
 import DatasetReferences from '~/components/DatasetDetails/DatasetReferences.vue'
 import DatasetMetrics from '~/components/DatasetDetails/DatasetMetrics.vue'
 import VersionHistory from '@/components/VersionHistory/VersionHistory.vue'
@@ -126,7 +127,7 @@ const getDatasetDetails = async (config, datasetId, version, $axios, $pennsieveA
   const url = `${config.public.portal_api}/sim/dataset/${datasetId}`
   var datasetUrl = version ? `${url}/versions/${version}` : url
 
-  const datasetDetails = await $axios.get(datasetUrl).catch(async (error) => { 
+  const datasetDetails = await $axios.get(datasetUrl).catch(async (error) => {
     const status = propOr('', 'status', error.response)
     // If not found, then try accessing it directly from Pennsieve in case it has been unpublished
     if (status == 404) {
@@ -221,6 +222,10 @@ const tabs = [
   {
     label: 'Cite',
     id: 'cite'
+  },
+  {
+    label: 'Gallery',
+    id: 'images'
   },
   {
     label: 'Metrics',

--- a/tests/cypress/e2e/datasets/detailtabs.cy.js
+++ b/tests/cypress/e2e/datasets/detailtabs.cy.js
@@ -407,6 +407,19 @@ datasetIds.forEach((datasetId) => {
       })
     })
 
+    describe('Gallery Tab', { testIsolation: false }, function () {
+
+      beforeEach(function () {
+        cy.clickOnDetailTab('Gallery').then((tab) => {
+          if (!tab) {
+            this.skip()
+          }
+        })
+      })
+
+      it('Gallery', function () { })
+    })
+
     describe('References Tab', { testIsolation: false }, function () {
 
       beforeEach(function () {

--- a/tests/cypress/e2e/datasets/imagegallery.cy.js
+++ b/tests/cypress/e2e/datasets/imagegallery.cy.js
@@ -32,7 +32,6 @@ datasetIds.forEach((datasetId) => {
             ('abi-scaffold-metadata-file' in response && response['abi-scaffold-metadata-file'].length) ||
             ('abi-simulation-omex-file' in response && response['abi-simulation-omex-file'].length) ||
             ('video' in response && response['video'].length) ||
-            ('organs' in response && response['organs'].length) ||
             ('abi-plot' in response && response['abi-plot'].length)
           ) {
             if ('abi-scaffold-metadata-file' in response && response['abi-scaffold-metadata-file'].length) {
@@ -40,9 +39,6 @@ datasetIds.forEach((datasetId) => {
             }
             if ('video' in response && response['video'].length) {
               existGalleryItems.push('Video')
-            }
-            if ('organs' in response && response['organs'].length) {
-              existGalleryItems.push('Flatmap')
             }
             if ('abi-simulation-omex-file' in response && response['abi-simulation-omex-file'].length) {
               existGalleryItems.push('Simulation')
@@ -54,7 +50,7 @@ datasetIds.forEach((datasetId) => {
           }
         } else {
           cy.get('.content > .full-size').should(($message) => {
-            expect($message, 'Gallery items not exist').to.contain('This dataset does not contain gallery items')
+            expect($message, 'Gallery items not exist').to.contain('This dataset does not contain any gallery item.')
           })
         }
       })

--- a/tests/cypress/e2e/datasets/imagegallery.cy.js
+++ b/tests/cypress/e2e/datasets/imagegallery.cy.js
@@ -1,2 +1,172 @@
-// Gallery tab has been removed as part of Biolucida deprecation.
-// This test file is skipped until a replacement gallery is implemented.
+import { retryableBefore, stringToArray, randomInteger } from '../../support/utils.js'
+
+/**
+ * List of dataset ids
+ */
+const datasetIds = stringToArray(Cypress.env('DATASET_IDS'), ',')
+
+const galleryItems = ['Scaffold', 'Video', 'Flatmap', 'Simulation', 'Plot']
+
+datasetIds.forEach((datasetId) => {
+
+  describe(`Dataset ${datasetId}`, { testIsolation: false }, function () {
+
+    let existGalleryItems = []
+
+    retryableBefore(function () {
+      cy.visit(`/datasets/${datasetId}?type=dataset&datasetDetailsTab=images`)
+    })
+
+    beforeEach(function () {
+      cy.intercept('**/dataset_info/using_doi?**').as('dataset_info')
+      cy.waitForPageLoading()
+    })
+
+    it('Gallery Item', function () {
+      cy.wait(5000)
+      cy.wait('@dataset_info', { timeout: 20000 }).then((intercept) => {
+        const response = intercept.response.body.result[0]
+        // Check if gallery cards loaded
+        if (response) {
+          if (
+            ('abi-scaffold-metadata-file' in response && response['abi-scaffold-metadata-file'].length) ||
+            ('abi-simulation-omex-file' in response && response['abi-simulation-omex-file'].length) ||
+            ('video' in response && response['video'].length) ||
+            ('organs' in response && response['organs'].length) ||
+            ('abi-plot' in response && response['abi-plot'].length)
+          ) {
+            if ('abi-scaffold-metadata-file' in response && response['abi-scaffold-metadata-file'].length) {
+              existGalleryItems.push('Scaffold')
+            }
+            if ('video' in response && response['video'].length) {
+              existGalleryItems.push('Video')
+            }
+            if ('organs' in response && response['organs'].length) {
+              existGalleryItems.push('Flatmap')
+            }
+            if ('abi-simulation-omex-file' in response && response['abi-simulation-omex-file'].length) {
+              existGalleryItems.push('Simulation')
+            }
+            if ('abi-plot' in response && response['abi-plot'].length) {
+              existGalleryItems.push('Plot')
+            }
+            cy.checkGalleyCardState()
+          }
+        } else {
+          cy.get('.content > .full-size').should(($message) => {
+            expect($message, 'Gallery items not exist').to.contain('This dataset does not contain gallery items')
+          })
+        }
+      })
+    })
+
+    describe('Viewer', { testIsolation: false }, function () {
+
+      galleryItems.forEach((item) => {
+
+        it(item, function () {
+          if (existGalleryItems.includes(item)) {
+            cy.waitForGalleryLoading()
+            cy.get('.filter-container > .filter-dropdown').click()
+            cy.get('.el-cascader-node').then(($content) => {
+              if (!$content.text().includes(item) && !$content.text().includes(item.toLowerCase())) {
+                this.skip()
+              }
+            })
+            cy.get('.el-cascader-node').contains(new RegExp(item, 'i')).parent().siblings().click()
+            cy.window().then((window) => {
+              cy.stub(window.document.body, 'appendChild').as('cardClicked')
+            })
+            cy.get('.el-pager > .number').then(($pages) => {
+              if ($pages.length > 1) {
+                const randomPage = randomInteger(0, $pages.length - 1)
+                cy.wrap($pages).eq(randomPage).click()
+              }
+              cy.get('.el-card > .el-card__body').then(($cards) => {
+                const randomCard = randomInteger(0, $cards.length - 1)
+                cy.wrap($cards).eq(randomCard).then(($card) => {
+                  cy.wrap($card).find('.el-button').click()
+                  cy.get('@cardClicked').should('be.calledWith', Cypress.sinon.match.any).then((stub) => {
+                    // Appended link element
+                    const element = stub.args[0][0]
+                    expect(element, 'Button should open a new tab').to.have.attr('target').to.contain('blank')
+                    cy.visit(element.href)
+                    cy.waitForPageLoading()
+                    if (item === 'Scaffold' || item === 'Flatmap') {
+                      // Check whether map viewer loaded or not
+                      cy.waitForViewerContainer('.mapClass')
+                      cy.get('.page-hero > .container').should(($content) => {
+                        expect($content, 'Map Viewer should display content').to.contain('Maps')
+                      })
+                      if (item === 'Scaffold') {
+                        cy.get('.pane-1 > .content-container > .toolbar > .toolbar-flex-container > .el-select > .el-select__wrapper > .el-select__selection > .el-select__placeholder > span').should(($title) => {
+                          expect($title, 'Map Viewer should display scaffold').to.contain('Scaffold')
+                        })
+                        cy.waitForScaffoldLoading()
+                        cy.checkScaffoldContextCard()
+                      }
+                      if (item === 'Flatmap') {
+                        cy.get('.toolbar-title').should(($title) => {
+                          expect($title, 'Map Viewer should display flatmap').to.contain('MultiFlatmap')
+                        })
+                      }
+                      cy.backToDetailPage(datasetId)
+                      cy.waitForPageLoading()
+                    } else {
+                      // Check whether metadata exist or not
+                      cy.waitForViewerContainer('.subpage')
+                      if (item === 'Video') {
+                        cy.get('video')
+                          .should('have.prop', 'paused', true)
+                          .and('have.prop', 'ended', false)
+                          .then(($video) => {
+                            $video[0].play()
+                          })
+                        // once the video starts playing, check props
+                        cy.get('video')
+                          .should('have.prop', 'paused', false)
+                          .and('have.prop', 'ended', false)
+                      }
+                      if (item === 'Simulation') {
+                        cy.get('.plot-container > .user-select-none.svg-container').then(($simulation) => {
+                          expect($simulation, 'Simulation should be displayed').to.exist
+                        })
+                      }
+                      if (item === 'Plot') {
+                        cy.get('.plot-container > .user-select-none.svg-container').then(($plot) => {
+                          expect($plot, 'Plot should be displayed').to.exist
+                        })
+                      }
+                      cy.wait(5000) // Wait for above actions to complete
+                      cy.get('.subpage > .file-detail > :nth-child(2)').each(($row) => {
+                        expect($row.text().length, 'Viewer metadata should exist').to.be.greaterThan(0)
+                      })
+                      cy.get('.subpage').contains('File location').siblings().find('a').then(($link) => {
+                        cy.wrap($link).click()
+                        cy.waitForPageLoading()
+                        const breadcrumbs = $link.text().split('/')
+                        cy.get('.breadcrumb-list .breadcrumb-link').each(($breadcrumb) => {
+                          expect(breadcrumbs, 'Filepath should contain all breadcrumbs').to.include($breadcrumb.text())
+                        })
+                        const filenameList = breadcrumbs[breadcrumbs.length - 1].match(/[a-z0-9]+/gi)
+                        const regex = new RegExp(filenameList.join('.*'), 'gi')
+                        cy.get('.truncated > a').then(($filenames) => {
+                          expect($filenames.text(), 'Filename should exist in the table').to.match(regex)
+                        })
+                      })
+                    }
+                    cy.then(() => {
+                      cy.clickOnDetailTab('Gallery')
+                    })
+                  })
+                })
+              })
+            })
+          } else {
+            this.skip()
+          }
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Reinstate image gallery on dataset page with supports for viewable types including videos, 3D scaffolds, AC flatmaps, FC flatmaps, simulations and plots.

The issue can be found here - https://github.com/nih-sparc/sparc-app-issues/issues/804

https://alan-wu-sparc-app.herokuapp.com/

https://alan-wu-sparc-app.herokuapp.com/datasets/462?type=simulation&datasetDetailsTab=images