### PR TITLE
Fix homepage sections not loading on navigation and page refresh

### DIFF
--- a/components/FeaturedData/FeaturedData.vue
+++ b/components/FeaturedData/FeaturedData.vue
@@ -40,6 +40,12 @@ watch(
   () => props.featuredData,
   (newVal) => {
     localFeaturedData.splice(0, localFeaturedData.length, ...newVal)
+    if (selectedCategory.value) {
+      localFeaturedData.forEach(({ fields }) => {
+        fields['linkWithFacets'] = getLink(fields, facets.value)
+      })
+      selectedCategoryFeaturedData.value = localFeaturedData.filter(data => data.fields.facetType == selectedCategory.value)
+    }
   }
 )
 watch(
@@ -60,7 +66,7 @@ watch(selectedCategory, async (newCategory) => {
     // Load facets to determine links for the featured data
     const algoliaIndex = $algoliaClient.initIndex(config.public.ALGOLIA_INDEX)
     const facetsData = await getAlgoliaFacets(algoliaIndex, facetPropPathMapping)
-    facets.value = facetsData.find(facet => facet.key == categoryKey)?.children || []
+    facets.value = Array.isArray(facetsData) ? (facetsData.find(facet => facet.key == categoryKey)?.children || []) : []
 
     // Update localFeaturedData with the links
     localFeaturedData.forEach(({ fields }) => {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -111,6 +111,7 @@ useHead({
   ]
 })
     
+const _consortiaCache = useState('_consortiaCache', () => null)
 const { data: consortiaItems, error: consortiaError } = useAsyncData('consortiaItems', async () => {
   try {
     const { items } = await $contentfulClient.getEntries({
@@ -118,17 +119,22 @@ const { data: consortiaItems, error: consortiaError } = useAsyncData('consortiaI
       order: 'fields.displayOrder',
       'fields.displayOnHomepage': true,
     })
+    _consortiaCache.value = items
     return items
   } catch (err) {
     console.error('Could not fetch consortia data from Contentful.', err)
     return []
   }
-})
+}, { getCachedData: () => _consortiaCache.value || undefined })
 
+const _homepageCache = useState('_homepageCache', () => null)
 const { data: homepageData, error: homepageError } = useAsyncData('homepage', async () => {
-  return $contentfulClient.getEntry(config.public.ctf_home_page_id);
-})
+  const result = await $contentfulClient.getEntry(config.public.ctf_home_page_id)
+  _homepageCache.value = result
+  return result
+}, { getCachedData: () => _homepageCache.value || undefined })
 
+const _featuredDataCategoriesCache = useState('_featuredDataCategoriesCache', () => null)
 const { data: featuredDataCategories, error: featuredDataCategoriesError } = useAsyncData('featuredDataCategories', async () => {
   let categories = []
   await $contentfulClient.getContentType('featuredData').then(contentType => {
@@ -138,18 +144,22 @@ const { data: featuredDataCategories, error: featuredDataCategoriesError } = use
       }
     })
   })
+  _featuredDataCategoriesCache.value = categories
   return categories
-})
+}, { getCachedData: () => _featuredDataCategoriesCache.value || undefined })
 
+const _featuredDatasetsCache = useState('_featuredDatasetsCache', () => null)
 const { data: featuredDatasets, error: featuredDatasetsError } = useAsyncData('featuredDatasets', async () => {
   try {
     const response = await $axios.get(`${config.public.portal_api}/get_featured_dataset`)
+    _featuredDatasetsCache.value = response.data?.datasets
     return response.data?.datasets
   } catch {
     const response = await $axios.get(`${config.public.discover_api_host}/datasets/32`)
+    _featuredDatasetsCache.value = [response.data]
     return [response.data]
   }
-});
+}, { getCachedData: () => _featuredDatasetsCache.value || undefined });
 
 const institutionId = computed(() => 
   pathOr(


### PR DESCRIPTION
useAsyncData re-fetches on every client-side navigation in Nuxt 3.8.x
by default, leaving homepageData null during the fetch and causing all
content sections to render empty (producing the stacked hr elements that
made margins appear to be 0). Added useState caches with getCachedData
callbacks so the SSR payload is reused on re-navigation without
unnecessary re-fetches.

Also fixed two bugs in FeaturedData: the featuredData prop watcher only
updated localFeaturedData but never re-filtered selectedCategoryFeaturedData,
so the gallery stayed empty when data arrived after selectedCategory was
already set. And getAlgoliaFacets returns {} on error, causing
facetsData.find() to throw a TypeError that silently killed the watcher.