### PR TITLE
Add viewer icons for NIfTI and Zarr zip files in file explorer

### DIFF
--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -213,6 +213,20 @@
                   </template>
                 </sparc-tooltip>
               </div>
+              <div v-if="isNiftiFile(scope.row.name)" class="circle" @click="openViewerFile(scope)">
+                <sparc-tooltip placement="bottom-center" content="Open NIfTI Viewer">
+                  <template #item>
+                    <svgo-icon-view class="action-icon" />
+                  </template>
+                </sparc-tooltip>
+              </div>
+              <div v-if="isZarrZipFile(scope.row.name)" class="circle" @click="openViewerFile(scope)">
+                <sparc-tooltip placement="bottom-center" content="Open Zarr Viewer">
+                  <template #item>
+                    <svgo-icon-view class="action-icon" />
+                  </template>
+                </sparc-tooltip>
+              </div>
               <div class="circle" @click="setDialogSelectedFile(scope)">
                 <sparc-tooltip placement="bottom-center">
                   <template #data>
@@ -757,6 +771,15 @@ export default {
       if (!fileName) return false
       const lowerName = fileName.toLowerCase()
       return lowerName.endsWith('.ome.tiff') || lowerName.endsWith('.ome.tif')
+    },
+    isNiftiFile: function(fileName) {
+      if (!fileName) return false
+      const lowerName = fileName.toLowerCase()
+      return lowerName.endsWith('.nii') || lowerName.endsWith('.nii.gz')
+    },
+    isZarrZipFile: function(fileName) {
+      if (!fileName) return false
+      return fileName.toLowerCase().endsWith('.zarr.zip')
     },
     openViewerFile(scope) {
       const route = {

--- a/components/FilesTable/FilesTable.vue
+++ b/components/FilesTable/FilesTable.vue
@@ -213,14 +213,14 @@
                   </template>
                 </sparc-tooltip>
               </div>
-              <div v-if="isNiftiFile(scope.row.name)" class="circle" @click="openViewerFile(scope)">
+              <div v-if="isNiftiFile(scope.row.name) && $config.public.SHOW_ORTHOGONAL_VIEWER == 'true'" class="circle" @click="openViewerFile(scope)">
                 <sparc-tooltip placement="bottom-center" content="Open NIfTI Viewer">
                   <template #item>
                     <svgo-icon-view class="action-icon" />
                   </template>
                 </sparc-tooltip>
               </div>
-              <div v-if="isZarrZipFile(scope.row.name)" class="circle" @click="openViewerFile(scope)">
+              <div v-if="isZarrZipFile(scope.row.name) && $config.public.SHOW_ORTHOGONAL_VIEWER == 'true'" class="circle" @click="openViewerFile(scope)">
                 <sparc-tooltip placement="bottom-center" content="Open Zarr Viewer">
                   <template #item>
                     <svgo-icon-view class="action-icon" />


### PR DESCRIPTION
  - Adds a view (eyeball) icon for NIfTI files (.nii, .nii.gz) and Zarr zip files (.zarr.zip) in the    
  dataset file explorer                                                                                 
  - Detection is extension-based (same pattern as existing OME-TIFF detection) — no dependency on       
  datasetScicrunch metadata                                                                             
  - Clicking the icon routes to the file viewer page (file-datasetId-datasetVersion) via the existing   
  openViewerFile method                                                                                 
  - Changes are in components/FilesTable/FilesTable.vue only