### PR TITLE
File details related image to related datasets

### DIFF
--- a/components/Gallery/GalleryItems/RelatedDatasetCard.vue
+++ b/components/Gallery/GalleryItems/RelatedDatasetCard.vue
@@ -14,7 +14,7 @@
         {{ datasetTitle }}
       </nuxt-link>-->
       <div class="description-container mb-4">
-        {{ datasetDescription }}
+        {{ datasetTitle }}
       </div>
       <nuxt-link
         :to="{
@@ -22,13 +22,10 @@
           params: {
             datasetId: datasetId
           },
-          query: {
-            datasetDetailsTab: 'images'
-          }
         }"
       >
         <el-button>
-          View Gallery
+          View Dataset
         </el-button>
       </nuxt-link>
     </el-row>
@@ -58,9 +55,6 @@ export default {
     datasetTitle() {
       return propOr('', 'name', this.item)
     },
-    datasetDescription() {
-      return propOr('', 'description', this.item)
-    },
     datasetBanner() {
       return propOr('', 'banner', this.item)
     }
@@ -73,7 +67,10 @@ export default {
   background-color: transparent;
   position: relative;
   cursor: default;
-  text-align: left;
+  text-align: center;
+  .el-row {
+    justify-content: center;
+  }
 }
 .banner-image {
   display: block;
@@ -87,6 +84,7 @@ export default {
 .description-container {
   display: -webkit-box;
   -webkit-box-orient: vertical;
+  align-content: center;
   overflow: hidden;
   text-overflow: ellipsis;
   -webkit-line-clamp: 6;

--- a/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
+++ b/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
@@ -41,7 +41,7 @@
       <div v-if="hasRelatedDatasets" class="container">
         <div class="subpage">
           <div class="heading3 mb-16">
-            Find related images among other datasets that share the same award id
+            Find related dataset under the same award id
           </div>
           <gallery galleryItemType="relatedDatasets" :items="relatedDatasets" :cardWidth="12" />
         </div>


### PR DESCRIPTION
Change the gallery under dataset file information in the file details page to link to the dataset instead of image gallery.

https://github.com/nih-sparc/sparc-app-issues/issues/960

This can be tested here - https://alan-wu-sparc-app.herokuapp.com/datasets/file/688/1?path=files/primary/sub-f020/sam-l/sam-l-seg-c1/2024_C1L_left_A_branch_between_cranial_nerve_bundle_and_superior_cervical_ganglion.mrk.json
