### PR TITLE
Added schema.org meta data to the header

### DIFF
--- a/pages/about/consortia/[id].vue
+++ b/pages/about/consortia/[id].vue
@@ -326,6 +326,7 @@ const consortiaStyle = computed(() => {
   }
   li {
     color: var(--button-and-link-color) !important;
+    border-color: var(--button-and-link-color) !important;
     background-color: var(--button-and-link-secondary-color) !important;
   }
   li.is-active {

--- a/pages/datasets/[datasetId].vue
+++ b/pages/datasets/[datasetId].vue
@@ -349,6 +349,38 @@ export default {
         await navigateTo(doiLink, { external: true, redirectCode: 301 })
       }
 
+      useHead(() => {
+        const info = store.datasetInfo
+        if (!info?.name) return {}
+        const infoDoi = propOr('', 'doi', info)
+        const tags = propOr([], 'tags', info)
+        const licenseKey = propOr('', 'license', info)
+        return {
+          script: [{
+            type: 'application/ld+json',
+            innerHTML: JSON.stringify({
+              '@context': 'http://schema.org/',
+              '@type': 'Dataset',
+              name: info.name,
+              description: info.description || undefined,
+              url: `${config.public.ROOT_URL}/datasets/${info.id}`,
+              image: info.banner || undefined,
+              identifier: infoDoi ? `https://doi.org/${infoDoi}` : undefined,
+              license: getLicenseLink(getLicenseAbbr(licenseKey)) || undefined,
+              version: info.version?.toString(),
+              datePublished: info.firstPublishedAt || undefined,
+              keywords: tags.length ? tags : undefined,
+              creator: creators,
+              publisher: {
+                '@type': 'Organization',
+                name: 'Pennsieve Discover'
+              }
+            }),
+            key: 'schema-org-dataset'
+          }]
+        }
+      })
+
       return {
         tabs: tabsData,
         versions,


### PR DESCRIPTION
The current dataset page has standard SEO meta tags but is was missing the schema.org JSON-LD blob