### PR TITLE
Harden SSR against bot attacks to protect Contentful and Algolia API quota

### DIFF
--- a/components/ContactUsForms/BugForm/BugForm.vue
+++ b/components/ContactUsForms/BugForm/BugForm.vue
@@ -226,25 +226,35 @@ export default {
     }
   },
 
-  mounted() {
-    const config = useRuntimeConfig()
-    // Reset form fields when showing the form
-    this.$refs.submitForm.resetFields()
-    this.hasError = false
-
-    if (this.bugSourceUrl != undefined) {
-      const fullUrl = config.public.ROOT_URL + this.bugSourceUrl
-      this.form.pageUrl = fullUrl.replace(/^https?:\/\//, '')
-    }
-
-    const form = loadForm()
-    if (form) {
-      this.form = {
-        ...this.form,
-        ...form
+  watch: {
+    bugSourceUrl(val) {
+      if (val != undefined && !this.form.pageUrl) {
+        const config = useRuntimeConfig()
+        const fullUrl = config.public.ROOT_URL + val
+        this.form.pageUrl = fullUrl.replace(/^https?:\/\//, '')
       }
     }
-    populateFormWithUserData(this.form, this.firstName, this.lastName, this.profileEmail)
+  },
+
+  mounted() {
+    this.hasError = false
+    this.$refs.submitForm.resetFields()
+    // resetFields() uses nextTick internally — run our setup after it completes
+    this.$nextTick(() => {
+      if (this.bugSourceUrl != undefined) {
+        const config = useRuntimeConfig()
+        const fullUrl = config.public.ROOT_URL + this.bugSourceUrl
+        this.form.pageUrl = fullUrl.replace(/^https?:\/\//, '')
+      }
+      const form = loadForm()
+      if (form) {
+        this.form = {
+          ...this.form,
+          ...form
+        }
+      }
+      populateFormWithUserData(this.form, this.firstName, this.lastName, this.profileEmail)
+    })
   },
 
   methods: {

--- a/pages/about/[aboutDetailsId].vue
+++ b/pages/about/[aboutDetailsId].vue
@@ -44,28 +44,19 @@ import ShareLinks from '~/components/ShareLinks/ShareLinks.vue'
 import { parseMarkdown } from '@/utils/formattingUtils.js'
 
 const config = useRuntimeConfig()
-const { $contentfulClient } = useNuxtApp()
 const { params } = useRoute()
 const router = useRouter()
 
 const { data: aboutDetailsItem } = useAsyncData('aboutDetailsItem', async () => {
   try {
-    const entries = await $contentfulClient.getEntries({
-      content_type: config.public.ctf_about_details_content_type_id,
-      'fields.slug': params.aboutDetailsId
-    })
-
-    if (entries.items.length === 0) {
-      const response = await $contentfulClient.getEntry(params.aboutDetailsId)
-      const slug = pathOr('', ['fields', 'slug'], response)
-
+    const result = await $fetch(`/api/contentful/about-details/${params.aboutDetailsId}`)
+    if (!result.foundBySlug) {
+      const slug = pathOr('', ['item', 'fields', 'slug'], result)
       if (!isEmpty(slug)) {
         await router.replace({ path: `/about/${slug}` })
       }
-      return response
-    } else {
-      return entries.items[0]
     }
+    return result.item
   } catch (err) {
     console.error('Error fetching about details item:', err)
     return null

--- a/pages/about/consortia/[id].vue
+++ b/pages/about/consortia/[id].vue
@@ -98,24 +98,13 @@ const config = useRuntimeConfig()
 const algoliaIndex = await $algoliaClient.initIndex(config.public.ALGOLIA_INDEX)
 
 const { data: consortiaItem, error: contentfulError, pending } = useAsyncData(
-  async () => {
-    const response = await $contentfulClient.getEntries({
-      content_type: config.public.ctf_consortia_content_type_id,
-      'fields.slug': route.params.id.toLowerCase(),
-    })
-    return pathOr([], ['items'], response)[0]
-  }
+  'consortia-' + route.params.id,
+  () => $fetch(`/api/contentful/consortia-item/${route.params.id}`)
 )
 
 const highlights = ref([])
-const { items } = await $contentfulClient
-  .getEntries({
-    content_type: config.public.ctf_news_id,
-    order: '-fields.publishedDate',
-    limit: 999,
-    'fields.consortiaHighlight[in]': consortiaItem.value?.fields?.slug,
-  })
-  highlights.value = items
+const highlightItems = await $fetch(`/api/contentful/consortia-news/${route.params.id}`)
+highlights.value = highlightItems || []
 
 const breadcrumb = [
   { to: { name: 'index' }, label: 'Home' },
@@ -221,6 +210,7 @@ const resetListOfAvailableDatasetIds = async (featuredDatasetIds, dateToShowFeat
 }
 
 const initFeaturedDatasets = async (item) => {
+  if (import.meta.server) return
   const fields = item.fields
   const featuredDatasetIds = pathOr('', ['featuredDatasets'], fields)
   const organizationIdFilter = pathOr('', ['organizationIdsForFeaturedDatasets'], fields)

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -82,9 +82,7 @@ const months = [
 
 const { data: pageData, error: pageDataError } = useAsyncData('pageData', async () => {
   try {
-    const { $contentfulClient } = useNuxtApp()
-    const cfPage = await $contentfulClient.getEntry(config.public.ctf_about_page_id)
-    return cfPage.fields
+    return await $fetch('/api/contentful/about-page')
   } catch (err) {
     console.error('Could not fetch page data from Contentful.', err)
     return {}
@@ -93,13 +91,7 @@ const { data: pageData, error: pageDataError } = useAsyncData('pageData', async 
 
 const { data: consortiaItems, error: consortiaError } = useAsyncData('consortiaItems', async () => {
   try {
-    const { $contentfulClient } = useNuxtApp()
-    const { items } = await $contentfulClient.getEntries({
-      content_type: config.public.ctf_consortia_content_type_id,
-      order: 'fields.displayOrder',
-      'fields.displayOnAboutPage': true
-    })
-    return items
+    return await $fetch('/api/contentful/about-consortia')
   } catch (err) {
     console.error('Could not fetch consortia data from Contentful.', err)
     return []
@@ -113,7 +105,7 @@ const { data: metricsData, error: metricsError } = useAsyncData('metricsData', a
     const response = await $axios.get(url)
     const algoliaMetricsData = response?.data?.find(item => item.Report === 'algolia') || {}
     return {
-      totalContributors: parseInt(algoliaMetricsData['contributors.name']['countributors_count']) || 0
+      totalContributors: parseInt(algoliaMetricsData?.['contributors.name']?.['countributors_count']) || 0
     }
   } catch (err) {
     console.error(err)
@@ -164,14 +156,7 @@ const { data: totalCitationsData, error: totalCitationsError } = useAsyncData('t
 
 const { data: highlights, error: highlightsError } = useAsyncData('highlightsData', async () => {
   try {
-    const { $contentfulClient } = useNuxtApp()
-    const response = await $contentfulClient.getEntries({
-      'content_type': config.public.ctf_news_id,
-      order: '-fields.publishedDate',
-      limit: 999,
-      'fields.subject': 'Highlight'
-    })
-    return response.items
+    return await $fetch('/api/contentful/highlights')
   } catch (err) {
     console.error('Could not retrieve highlights.', err)
     return []

--- a/pages/about/projects/[projectId].vue
+++ b/pages/about/projects/[projectId].vue
@@ -227,7 +227,7 @@ export default {
     const route = useRoute()
     const { $axios, $contentfulClient } = useNuxtApp()
     try {
-      const project = await $contentfulClient.getEntry(route.params.projectId)
+      const project = await $fetch(`/api/contentful/project/${route.params.projectId}`)
       const awards = pathOr(null, ['fields','awards'], project)
 
       let associatedDatasetsResults = await Promise.all(awards.map(async (award) => {

--- a/pages/about/projects/index.vue
+++ b/pages/about/projects/index.vue
@@ -146,36 +146,8 @@ export default {
 
   async setup() {
     const route = useRoute()
-    const { $contentfulClient } = useNuxtApp()
-
-    let projectsAnatomicalFocusFacets = []
-    let consortiaTypes = []
-    await $contentfulClient.getContentType('sparcAward').then(contentType => {
-      contentType.fields.forEach((field) => {
-        if (field.name === 'Funding') {
-          let fundingItems = field.items?.validations[0]['in']
-          let facetData = []
-          fundingItems.forEach(itemLabel => {
-            facetData.push({
-              label: itemLabel,
-              id: itemLabel,
-            })
-          })
-          consortiaTypes = facetData
-        }
-        if (field.name === 'Focus') {
-          let focusItems = field.items?.validations[0]['in']
-          let facetData = []
-          focusItems.forEach(itemLabel => {
-            facetData.push({
-              label: itemLabel,
-              id: itemLabel,
-            })
-          })
-          projectsAnatomicalFocusFacets = facetData
-        }
-      })
-    })
+    const { projectsAnatomicalFocusFacets, consortiaTypes } = await $fetch('/api/contentful/sparc-award-types')
+      .catch(() => ({ projectsAnatomicalFocusFacets: [], consortiaTypes: [] }))
     return {
       projectsSortOptions,
       selectedProjectsSortOption: ref(projectsSortOptions.find(opt => opt.id === route.query.projectsSort) || projectsSortOptions[0]),

--- a/pages/apps/index.vue
+++ b/pages/apps/index.vue
@@ -67,8 +67,7 @@ const constructPortalFeatureEntries = (apps) => {
 const config = useRuntimeConfig()
 
 const { data: appData } = await useAsyncData('apps-page-data', async () => {
-  const { $contentfulClient } = useNuxtApp()
-  const appPage = await $contentfulClient.getEntry(config.public.ctf_apps_page_id)
+  const appPage = await $fetch('/api/contentful/apps-page')
   return {
     fields: appPage.fields || {},
     appEntries: constructPortalFeatureEntries(appPage.fields?.apps),

--- a/pages/apps/maps/index.vue
+++ b/pages/apps/maps/index.vue
@@ -481,23 +481,25 @@ export default {
     if (lastChar != '/') {
       options.sparcApi = options.sparcApi + '/'
     }
-    const algoliaIndex = await $algoliaClient.initIndex(config.public.ALGOLIA_INDEX)
-    const appPage = await $contentfulClient.getEntry(config.public.ctf_apps_page_id)
+    const algoliaIndex = import.meta.server ? null : await $algoliaClient.initIndex(config.public.ALGOLIA_INDEX)
+    const appPage = await $fetch('/api/contentful/apps-page')
     const clientOnly = process.client
 
-    if (route.query.id) {
-      [uuid, state, successMessage, failMessage] = await restoreStateWithUUID(clientOnly, route, $axios, options.sparcApi)
-    } else {
-      //Now check if it should open a specific view based on query
-      [
-        startingMap,
-        organ_name,
-        currentEntry,
-        successMessage,
-        failMessage,
-        facets
-      ] = await openViewWithQuery(router, route, $axios, options.sparcApi, algoliaIndex,
-        config.public.discover_api_host, $pennsieveApiClient)
+    if (!import.meta.server) {
+      if (route.query.id) {
+        [uuid, state, successMessage, failMessage] = await restoreStateWithUUID(clientOnly, route, $axios, options.sparcApi)
+      } else {
+        //Now check if it should open a specific view based on query
+        [
+          startingMap,
+          organ_name,
+          currentEntry,
+          successMessage,
+          failMessage,
+          facets
+        ] = await openViewWithQuery(router, route, $axios, options.sparcApi, algoliaIndex,
+          config.public.discover_api_host, $pennsieveApiClient)
+      }
     }
 
     return {

--- a/pages/apps/sparc-dashboard/index.vue
+++ b/pages/apps/sparc-dashboard/index.vue
@@ -52,8 +52,6 @@ import "sparc-dashwidgets/style.css"
 
 const config = useRuntimeConfig()
 
-const { $contentfulClient } = useNuxtApp()
-
 const breadcrumb = [
   {
     label: "Home",
@@ -190,9 +188,7 @@ const dashboardOptions = ref({
 const { data: dashboardData } = await useAsyncData(
   "dashboardPage",
   async () => {
-    const pageData = await $contentfulClient.getEntry(
-      config.public.ctf_sparc_dashboard_entry_id
-    );
+    const pageData = await $fetch('/api/contentful/sparc-dashboard')
     return {
       fields: pageData.fields || {},
     };

--- a/pages/collections/[collectionId].vue
+++ b/pages/collections/[collectionId].vue
@@ -646,10 +646,8 @@ export default {
     },
     getAssociatedProjects: async function (sparcAwardNumbers) {
       try {
-        const projects = await this.$contentfulClient.getEntries({
-          content_type: this.$config.public.ctf_project_id,
-        })
-        const associatedProjects = projects.items?.filter((project) => {
+        const projects = await $fetch('/api/contentful/projects')
+        const associatedProjects = projects?.filter((project) => {
           const awards = pathOr([], ['fields', 'awards'], project)
           return awards.some(award => sparcAwardNumbers.includes(award.fields.title))
         })

--- a/pages/contact-us/index.vue
+++ b/pages/contact-us/index.vue
@@ -163,25 +163,17 @@ export default {
   mixins: [MarkedMixin],
 
   setup() {
-    const { $contentfulClient } = useNuxtApp()
-    const config = useRuntimeConfig()
-    //useRecaptchaProvider()
-    return $contentfulClient
-      .getEntries({
-        content_type: config.public.ctf_contact_us_form_type_id,
-      })
-      .then(({items}) => {
+    return $fetch('/api/contentful/contact-us-form-types')
+      .then(items => {
         const extendedFormTypes = formTypes.map(formType => {
-          const entry = items.find(item => item.sys.id === formType.id)
+          const entry = items?.find(item => item.id === formType.id)
           return {
             ...formType,
-            label: entry.fields.title,
-            description: entry.fields.description
+            label: entry?.label || '',
+            description: entry?.description || '',
           }
         })
-        return {
-          formTypes: extendedFormTypes
-        }
+        return { formTypes: extendedFormTypes }
       })
       .catch(console.error)
   },

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -223,7 +223,7 @@ export default {
         algoliaIndexName: config.public.ALGOLIA_INDEX_ALPHABETICAL_Z_A
       },
     ]
-    const algoliaIndex = await $algoliaClient.initIndex(config.public.ALGOLIA_INDEX_VERSION_PUBLISHED_TIME_DESC)
+    const algoliaIndex = import.meta.server ? null : await $algoliaClient.initIndex(config.public.ALGOLIA_INDEX_VERSION_PUBLISHED_TIME_DESC)
 
     const searchType = searchTypes.find(searchType => {
       return searchType.type == route.query.type
@@ -371,6 +371,7 @@ export default {
 
     selectedAlgoliaSortOption: {
       handler: function (option) {
+        if (import.meta.server) return
         this.algoliaIndex = this.$algoliaClient.initIndex(option.algoliaIndexName)
       },
       immediate: true
@@ -433,6 +434,7 @@ export default {
     },
 
     fetchResults: function () {
+      if (import.meta.server) return
       this.isLoadingSearch = true
       this.searchFailed = false
       const query = this.$route.query.search

--- a/pages/datasets/[datasetId].vue
+++ b/pages/datasets/[datasetId].vue
@@ -100,7 +100,6 @@
 <script>
 import Tombstone from '@/components/Tombstone/Tombstone.vue'
 import { clone, isEmpty, propOr, pathOr, head, compose } from 'ramda'
-import { getAlgoliaFacets, facetPropPathMapping } from '../../utils/algolia'
 import { useMainStore } from '../store/index.js'
 import { mapState, mapActions } from 'pinia'
 import DatasetVersionMessage from '@/components/DatasetVersionMessage/DatasetVersionMessage.vue'
@@ -183,32 +182,6 @@ const getDownloadsSummary = async (config, axios) => {
   }
 }
 
-const getOrganizationIds = async (algoliaIndex) => {
-  try {
-    const { facets } = await algoliaIndex.search('', {
-      hitsPerPage: 0,
-      sortFacetValuesBy: 'alpha',
-      facets: 'pennsieve.organization.identifier',
-    })
-    return Object.keys(facets['pennsieve.organization.identifier'])
-  } catch (error) {
-    return [
-      29, //IT'IS Foundation
-      367, // SPARC
-      661, // RE-JOIN
-      666, // PRECISION
-    ]
-  }
-}
-
-const getAlgoliaMetadata = async (algoliaIndex, id) => {
-  try {
-    const response = await algoliaIndex.getObject(id)
-    return response
-  } catch (error) {
-    return null
-  }
-}
 
 const tabs = [
   {
@@ -265,19 +238,18 @@ export default {
     }
     const config = useRuntimeConfig()
     const { $algoliaClient, $axios, $pennsieveApiClient } = useNuxtApp()
-    const algoliaIndex = await $algoliaClient.initIndex(config.public.ALGOLIA_INDEX_PUBLISHED_TIME_DESC)
+    const algoliaIndex = $algoliaClient.initIndex(config.public.ALGOLIA_INDEX_PUBLISHED_TIME_DESC)
 
     let tabsData = clone(tabs)
     const datasetId = route.params.datasetId
-    const filter = `objectID:${datasetId}`
-    const datasetFacetsData = await getAlgoliaFacets(algoliaIndex, facetPropPathMapping, filter).then(data => {
-      return data
-    })
+    const store = useMainStore()
+    const [datasetFacetsData] = await Promise.all([
+      $fetch(`/api/algolia/dataset-facets?id=${datasetId}`).catch(() => [])
+    ])
     // If the algolia index returns nothing than the dataset has not been indexed and we should not display the details page
     const isDatasetIndexed = !isEmpty(datasetFacetsData)
     const typeFacet = datasetFacetsData.find(child => child.key === 'item.types.name')
     const datasetTypeName = typeFacet !== undefined ? typeFacet.children[0].label : 'dataset'
-    const store = useMainStore()
     try {
       let [datasetDetails, citationsInfo, versions, downloadsSummary, sparcOrganizationIds, algoliaDatasetMetadata] = await Promise.all([
         getDatasetDetails(
@@ -290,8 +262,8 @@ export default {
         getCitationsInfo(config, datasetId, $axios),
         getDatasetVersions(config, datasetId, $axios),
         getDownloadsSummary(config, $axios),
-        getOrganizationIds(algoliaIndex),
-        getAlgoliaMetadata(algoliaIndex, datasetId)
+        $fetch('/api/algolia/organization-ids').catch(() => [29, 367, 661, 666]),
+        $fetch(`/api/algolia/dataset-metadata?id=${datasetId}`).catch(() => null)
       ])
       // get contributors from Algolia and replace the list retrieved from Pennsieve because the Pennsieve list is based off
       // the user's Pennsieve account names instead of the dataset_description.xlsx file which is the point of truth. Refer to
@@ -748,10 +720,8 @@ export default {
     },
     getAssociatedProjects: async function (sparcAwardNumbers) {
       try {
-        const projects = await this.$contentfulClient.getEntries({
-          content_type: this.$config.public.ctf_project_id,
-        })
-        const associatedProjects = projects.items?.filter((project) => {
+        const projects = await $fetch('/api/contentful/projects')
+        const associatedProjects = projects?.filter((project) => {
           const awards = pathOr([], ['fields', 'awards'], project)
           return awards.some(award => sparcAwardNumbers.includes(award.fields.title))
         })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -52,7 +52,7 @@ import { pathOr } from 'ramda'
 import { useRuntimeConfig, useAsyncData } from '#app'
 
 const config = useRuntimeConfig()
-const { $contentfulClient, $axios } = useNuxtApp()
+const { $axios } = useNuxtApp()
 useHead({
   title: 'SPARC Portal',
   meta: [
@@ -114,11 +114,7 @@ useHead({
 const _consortiaCache = useState('_consortiaCache', () => null)
 const { data: consortiaItems, error: consortiaError } = useAsyncData('consortiaItems', async () => {
   try {
-    const { items } = await $contentfulClient.getEntries({
-      content_type: config.public.ctf_consortia_content_type_id,
-      order: 'fields.displayOrder',
-      'fields.displayOnHomepage': true,
-    })
+    const items = await $fetch('/api/contentful/homepage-consortia')
     _consortiaCache.value = items
     return items
   } catch (err) {
@@ -129,21 +125,14 @@ const { data: consortiaItems, error: consortiaError } = useAsyncData('consortiaI
 
 const _homepageCache = useState('_homepageCache', () => null)
 const { data: homepageData, error: homepageError } = useAsyncData('homepage', async () => {
-  const result = await $contentfulClient.getEntry(config.public.ctf_home_page_id)
+  const result = await $fetch('/api/contentful/homepage')
   _homepageCache.value = result
   return result
 }, { getCachedData: () => _homepageCache.value || undefined })
 
 const _featuredDataCategoriesCache = useState('_featuredDataCategoriesCache', () => null)
 const { data: featuredDataCategories, error: featuredDataCategoriesError } = useAsyncData('featuredDataCategories', async () => {
-  let categories = []
-  await $contentfulClient.getContentType('featuredData').then(contentType => {
-    contentType.fields.forEach((field) => {
-      if (field.id === 'facetType') {
-        categories = field.items?.validations[0]['in']
-      }
-    })
-  })
+  const categories = await $fetch('/api/contentful/featured-data-categories').catch(() => [])
   _featuredDataCategoriesCache.value = categories
   return categories
 }, { getCachedData: () => _featuredDataCategoriesCache.value || undefined })
@@ -173,7 +162,7 @@ const { data: institutionData, error: institutionError } = useAsyncData(
   'institution',
   async () => {
     if (!institutionId.value) return null;
-    return $contentfulClient.getEntry(institutionId.value);
+    return $fetch(`/api/contentful/entry/${institutionId.value}`).catch(() => null);
   },
   { watch: [institutionId] }
 );

--- a/pages/news-and-events/community-spotlight/index.vue
+++ b/pages/news-and-events/community-spotlight/index.vue
@@ -154,7 +154,6 @@ import SearchControlsContentful from '@/components/SearchControlsContentful/Sear
 import SortMenu from '@/components/SortMenu/SortMenu.vue'
 import SubmitCommunitySection from '~/components/NewsEventsResourcesPage/SubmitCommunitySection.vue'
 import AlternativeSearchResultsNews from '~/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue'
-import { fetchCommunitySpotlightItems } from '../model.js'
 
 
 const searchTypes = [
@@ -170,7 +169,6 @@ const sortOptions = [
 ]
 
 const route = useRoute()
-const { $contentfulClient } = useNuxtApp()
 
 const altSearchResults = ref(null)
 const communitySpotlightFacetMenu = ref(null)
@@ -209,68 +207,53 @@ const curSearchPage = computed(() => {
   return communitySpotlightItems.value?.skip / communitySpotlightItems.value?.limit + 1
 })
 
-const { data: communitySpotlightItems } = useAsyncData('communitySpotlightItems', () => {
-  return fetchCommunitySpotlightItems($contentfulClient, route.query.search, spotlightTypes.value, selectedAnatomicalStructures.value, sortOrder.value, 10, 0)
-})
+const fetchItems = (limit = 10, skip = 0, overrideSortOrder = null) =>
+  $fetch('/api/contentful/community-spotlight-items', {
+    params: {
+      search: route.query.search || undefined,
+      spotlightTypes: spotlightTypes.value || undefined,
+      anatomicalStructures: selectedAnatomicalStructures.value?.join(',') || undefined,
+      sortOrder: overrideSortOrder || sortOrder.value,
+      limit,
+      skip
+    }
+  }).catch(() => ({}))
 
-const { data: anatomicalStructures } = useAsyncData('anatomicalStructures', async () => {
-  let anatomicalStructures = {}
-  await $contentfulClient.getContentType('communitySpotlight').then(contentType => {
-    contentType.fields.forEach((field) => {
-      if (field.id === 'anatomicalStructure') {
-        let structures = field.items?.validations[0]['in']
-        let facetData = []
-        structures.forEach(itemLabel => {
-          facetData.push({
-            label: itemLabel,
-            id: itemLabel,
-          })
-        })
-        anatomicalStructures = {
-          label: 'Focus',
-          id: 'spotlightAnatomicalStructure',
-          data: facetData
-        }
-      }
-    })
-  })
-  return anatomicalStructures
-})
+const { data: communitySpotlightItems } = await useAsyncData('communitySpotlightItems', () =>
+  fetchItems()
+)
+
+const { data: anatomicalStructuresRaw } = await useAsyncData('anatomicalStructures', () =>
+  $fetch('/api/contentful/community-spotlight-types').catch(() => ({}))
+)
+const anatomicalStructures = computed(() => anatomicalStructuresRaw.value || {})
 
 watch(
   () => route.query,
   async () => {
-    communitySpotlightItems.value = await fetchCommunitySpotlightItems(
-      $contentfulClient,
-      route.query.search,
-      spotlightTypes.value,
-      selectedAnatomicalStructures.value,
-      sortOrder.value,
-      10,
-      0
-    )
+    communitySpotlightItems.value = await fetchItems()
     altSearchResults.value?.retrieveAltTotals()
-  },
-  { immediate: true }
+  }
 )
 
 const onPaginationPageChange = async (page) => {
-  const { limit } = communitySpotlightItems.value
+  const limit = communitySpotlightItems.value?.limit || 10
   const offset = (page - 1) * limit
-  const response = await fetchCommunitySpotlightItems($contentfulClient, route.query.search, spotlightTypes.value, selectedAnatomicalStructures.value, sortOrder.value, limit, offset)
-  communitySpotlightItems.value = response
+  communitySpotlightItems.value = await fetchItems(limit, offset)
 }
 
 const onPaginationLimitChange = async (limit) => {
   const newLimit = limit === 'View All' ? communitySpotlightItems.value?.total : limit
-  const response = await fetchCommunitySpotlightItems($contentfulClient, route.query.search, spotlightTypes.value, selectedAnatomicalStructures.value, sortOrder.value, newLimit, 0)
-  communitySpotlightItems.value = response
+  communitySpotlightItems.value = await fetchItems(newLimit, 0)
 }
 
 const onSortOptionChange = async (option) => {
   selectedSortOption.value = option
-  const response = await fetchCommunitySpotlightItems($contentfulClient, route.query.search, spotlightTypes.value, selectedAnatomicalStructures.value, sortOrder.value, communitySpotlightItems.value.limit, 0)
-  communitySpotlightItems.value = response
+  communitySpotlightItems.value = await fetchItems(
+    communitySpotlightItems.value?.limit || 10,
+    0,
+    propOr('-fields.publishedDate', 'sortOrder', option)
+  )
 }
 
 const altResultsMounted = () => {

--- a/pages/news-and-events/community-spotlight/success-stories/[id].vue
+++ b/pages/news-and-events/community-spotlight/success-stories/[id].vue
@@ -99,24 +99,12 @@ import { parseMarkdown } from '@/utils/formattingUtils.js'
 import { formatDate } from '@/utils/dateUtils.js'
 import ShareLinks from '~/components/ShareLinks/ShareLinks.vue'
 
-const { $contentfulClient } = useNuxtApp()
 const route = useRoute()
 
 // Fetch data using useAsyncData to avoid rendering on both client and server
-const { data, error } = await useAsyncData('story', async () => {
-  try {
-    const results = await $contentfulClient.getEntries({
-      content_type: 'successStoryDisplay',
-      'fields.storyRoute[match]': route.params.id,
-      include: 1,
-      order: '-fields.publishedDate',
-    })
-    return results.items[0]?.fields || {}
-  } catch (err) {
-    console.error(err)
-    return {}
-  }
-})
+const { data, error } = await useAsyncData('story', () =>
+  $fetch(`/api/contentful/success-story/${route.params.id}`).catch(() => ({}))
+)
 
 // Variables from the fetched data
 const entry = computed(() => data.value || {})

--- a/pages/news-and-events/events/[eventId]/event-details/index.vue
+++ b/pages/news-and-events/events/[eventId]/event-details/index.vue
@@ -38,19 +38,9 @@ import FormatDate from '@/mixins/format-date'
 import { pathOr, isEmpty } from 'ramda'
 
 const getEventPage = async id => {
-  const { $contentfulClient } = useNuxtApp()
-  const config = useRuntimeConfig()
   try {
-    const isSlug = id.split('-').length > 1
-
-    const item = isSlug
-      ? await $contentfulClient.getEntries({
-          content_type: config.public.ctf_event_id,
-          'fields.slug': id
-        })
-      : await $contentfulClient.getEntry(id)
-    return isSlug ? item.items[0] : item
-  } catch (error) {
+    return await $fetch(`/api/contentful/event/${id}`)
+  } catch {
     return {}
   }
 }

--- a/pages/news-and-events/events/[id].vue
+++ b/pages/news-and-events/events/[id].vue
@@ -46,23 +46,12 @@ import { formatDate } from '@/utils/dateUtils.js'
 
 const route = useRoute()
 const router = useRouter()
-const { $contentfulClient } = useNuxtApp()
-const config = useRuntimeConfig()
 
 const { data: page, error } = useAsyncData(
   'eventPage',
   async () => {
     const id = route.params.id;
-    const isSlug = id.split('-').length > 1
-
-    const result = isSlug
-      ? await $contentfulClient.getEntries({
-          content_type: config.public.ctf_event_id,
-          'fields.slug': id
-        })
-      : await $contentfulClient.getEntry(id);
-
-    const eventPage = isSlug ? result.items[0] : result
+    const eventPage = await $fetch(`/api/contentful/event/${id}`).catch(() => null)
 
     // Redirect if the slug doesn't match
     const slug = pathOr(null, ['fields', 'slug'], eventPage)

--- a/pages/news-and-events/events/index.vue
+++ b/pages/news-and-events/events/index.vue
@@ -144,7 +144,6 @@ import SearchControlsContentful from '@/components/SearchControlsContentful/Sear
 import SortMenu from '@/components/SortMenu/SortMenu.vue'
 import SubmitNewsSection from '~/components/NewsEventsResourcesPage/SubmitNewsSection.vue'
 import AlternativeSearchResultsNews from '~/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue'
-import { fetchEvents } from '../model'
 
 const searchTypes = [
   { label: 'News', path: 'news' },
@@ -160,7 +159,6 @@ const sortOptions = [
 ]
 
 const route = useRoute()
-const { $contentfulClient } = useNuxtApp()
 
 const altSearchResults = ref(null)
 const eventsFacetMenu = ref(null)
@@ -172,10 +170,20 @@ const breadcrumb = [
   { label: 'News & Events', to: { name: 'news-and-events' } }
 ]
 
-// Fetch events data using `useAsyncData` for server-side rendering
-const { data: eventsData } = useAsyncData('eventsData', async () => {
-  return await fetchEvents($contentfulClient, route.query.search, startLessThanDate.value, startGreaterThanOrEqualToDate.value, eventTypes.value, sortOrder.value, 10, 0)
-})
+const fetchEventsItems = (limit = 10, skip = 0, overrideSortOrder = null) =>
+  $fetch('/api/contentful/events-items', {
+    params: {
+      search: route.query.search || undefined,
+      startLessThan: startLessThanDate.value || undefined,
+      startGte: startGreaterThanOrEqualToDate.value || undefined,
+      eventTypes: eventTypes.value || undefined,
+      sortOrder: overrideSortOrder || sortOrder.value,
+      limit,
+      skip
+    }
+  }).catch(() => ({}))
+
+const { data: eventsData } = await useAsyncData('eventsData', () => fetchEventsItems())
 
 const eventItems = computed(() => {
   return eventsData.value?.items
@@ -226,41 +234,22 @@ const showPastEventsDivider = computed(() => {
 watch(
   () => route.query,
   async () => {
-    // Have to do this anywhere we are setting eventsData.value in order to force reactivity to work since we are relying on nested reactivity causing some Vue reactivity quirkyness with eventsData.items.
     eventsData.value = { ...eventsData.value, items: [] }
     await nextTick()
-    eventsData.value = await fetchEvents(
-      $contentfulClient,
-      route.query.search, 
-      startLessThanDate.value, 
-      startGreaterThanOrEqualToDate.value,
-      eventTypes.value, 
-      sortOrder.value, 
-      10, 
-      0
-    )
+    eventsData.value = await fetchEventsItems()
     altSearchResults.value?.retrieveAltTotals()
   }
 )
 
 onMounted(async () => {
-  eventsData.value = await fetchEvents(
-      $contentfulClient,
-      route.query.search, 
-      startLessThanDate.value, 
-      startGreaterThanOrEqualToDate.value,
-      eventTypes.value, 
-      sortOrder.value, 
-      10, 
-      0
-    )
+  eventsData.value = await fetchEventsItems()
   altSearchResults.value?.retrieveAltTotals()
 })
 
 const onPaginationPageChange = async (page) => {
   const limit = eventsData.value?.limit || 10
   const offset = (page - 1) * limit || 0
-  const response = await fetchEvents($contentfulClient, route.query.search, startLessThanDate.value, startGreaterThanOrEqualToDate.value, eventTypes.value, sortOrder.value, limit, offset)
+  const response = await fetchEventsItems(limit, offset)
   eventsData.value = { ...eventsData.value, items: [] }
   await nextTick()
   eventsData.value = response
@@ -268,7 +257,7 @@ const onPaginationPageChange = async (page) => {
 
 const onPaginationLimitChange = async (limit) => {
   const newLimit = limit === 'View All' ? eventsData.value?.total : limit
-  const response = await fetchEvents($contentfulClient, route.query.search, startLessThanDate.value, startGreaterThanOrEqualToDate.value, eventTypes.value, sortOrder.value, newLimit, 0)
+  const response = await fetchEventsItems(newLimit, 0)
   eventsData.value = { ...eventsData.value, items: [] }
   await nextTick()
   eventsData.value = response
@@ -276,7 +265,11 @@ const onPaginationLimitChange = async (limit) => {
 
 const onSortOptionChange = async (option) => {
   selectedSortOption.value = option
-  const response = await fetchEvents($contentfulClient, route.query.search, startLessThanDate.value, startGreaterThanOrEqualToDate.value, eventTypes.value, sortOrder.value, eventsData.value.limit, 0)
+  const response = await fetchEventsItems(
+    eventsData.value?.limit || 10,
+    0,
+    propOr('-fields.startDate', 'sortOrder', option)
+  )
   eventsData.value = { ...eventsData.value, items: [] }
   await nextTick()
   eventsData.value = response

--- a/pages/news-and-events/index.vue
+++ b/pages/news-and-events/index.vue
@@ -143,10 +143,9 @@ const breadcrumb = [
 const title = 'News & Events';
 
 // Fetch initial data
-const { data: pageData } = await useAsyncData(() => {
-  const { $contentfulClient } = useNuxtApp()
-  return fetchData($contentfulClient, '', 2)
-});
+const { data: pageData } = await useAsyncData(() =>
+  $fetch('/api/contentful/news-and-events').catch(() => ({ upcomingEvents: {}, news: {}, page: {}, stories: {} }))
+);
 
 const page = computed(() => pageData.value?.page || {})
 const news = computed(() => pageData.value?.news || {})

--- a/pages/news-and-events/news/[id].vue
+++ b/pages/news-and-events/news/[id].vue
@@ -51,17 +51,10 @@ const breadcrumb = [
 ]
 
 const route = useRoute();
-const { $contentfulClient } = useNuxtApp()
 
 const { data: page, error } = useAsyncData(
   'newsPage',
-  async () => {
-    try {
-      return await $contentfulClient.getEntry(route.params.id);
-    } catch {
-      return { fields: [] };
-    }
-  }
+  () => $fetch(`/api/contentful/entry/${route.params.id}`).catch(() => ({ fields: [] }))
 )
 
 const newsImage = computed(() =>

--- a/pages/news-and-events/news/index.vue
+++ b/pages/news-and-events/news/index.vue
@@ -143,7 +143,6 @@ import SearchControlsContentful from '@/components/SearchControlsContentful/Sear
 import SortMenu from '@/components/SortMenu/SortMenu.vue'
 import SubmitNewsSection from '~/components/NewsEventsResourcesPage/SubmitNewsSection.vue'
 import AlternativeSearchResultsNews from '~/components/AlternativeSearchResults/AlternativeSearchResultsNews.vue'
-import { fetchNews } from '../model'
 
 const searchTypes = [
   { label: 'News', path: 'news' },
@@ -158,7 +157,6 @@ const sortOptions = [
 ]
 
 const route = useRoute()
-const { $contentfulClient } = useNuxtApp()
 
 const altSearchResults = ref(null)
 const newsFacetMenu = ref(null)
@@ -170,66 +168,54 @@ const breadcrumb = [
   { label: 'News & Events', to: { name: 'news-and-events' } }
 ]
 
-const publishedLessThanDate = computed(() => {
-  return newsFacetMenu.value?.getPublishedLessThanDate()
-})
+const publishedLessThanDate = computed(() => newsFacetMenu.value?.getPublishedLessThanDate())
+const publishedGreaterThanOrEqualToDate = computed(() => newsFacetMenu.value?.getPublishedGreaterThanOrEqualToDate())
+const subjects = computed(() => route.query.selectedNewsSubjectIds || undefined)
+const sortOrder = computed(() => propOr('-fields.publishedDate', 'sortOrder', selectedSortOption.value))
 
-const publishedGreaterThanOrEqualToDate = computed(() => {
-  return newsFacetMenu.value?.getPublishedGreaterThanOrEqualToDate()
-})
+const fetchNewsItems = (limit = 10, skip = 0, overrideSortOrder = null) =>
+  $fetch('/api/contentful/news-items', {
+    params: {
+      search: route.query.search || undefined,
+      publishedLessThan: publishedLessThanDate.value || undefined,
+      publishedGte: publishedGreaterThanOrEqualToDate.value || undefined,
+      subjects: subjects.value || undefined,
+      sortOrder: overrideSortOrder || sortOrder.value,
+      limit,
+      skip
+    }
+  }).catch(() => ({}))
 
-const subjects = computed(() => {
-  return route.query.selectedNewsSubjectIds || undefined
-})
+const { data: news } = await useAsyncData('news', () => fetchNewsItems())
 
-const sortOrder = computed(() => {
-  return propOr('-fields.publishedDate', 'sortOrder', selectedSortOption.value)
-})
-
-const { data: news } = useAsyncData('news', () => {
-  return fetchNews($contentfulClient, route.query.search, publishedLessThanDate.value,
-  publishedGreaterThanOrEqualToDate.value, subjects.value, sortOrder.value, 10, 0)
-})
-
-const curSearchPage = computed(() => {
-  return news.value?.skip / news.value?.limit + 1
-})
+const curSearchPage = computed(() => news.value?.skip / news.value?.limit + 1)
 
 watch(
   () => route.query,
   async () => {
-    news.value = await fetchNews(
-      $contentfulClient,
-      route.query.search,
-      publishedLessThanDate.value,
-      publishedGreaterThanOrEqualToDate.value,
-      subjects.value,
-      sortOrder.value,
-      10,
-      0
-    );
+    news.value = await fetchNewsItems()
     altSearchResults.value?.retrieveAltTotals()
-  },
-  { immediate: true }
+  }
 )
 
 const onPaginationPageChange = async (page) => {
-  const { limit } = news.value
+  const limit = news.value?.limit || 10
   const offset = (page - 1) * limit
-  const response = await fetchNews($contentfulClient, route.query.search, publishedLessThanDate.value, publishedGreaterThanOrEqualToDate.value, subjects.value, sortOrder.value, limit, offset)
-  news.value = response
+  news.value = await fetchNewsItems(limit, offset)
 }
 
 const onPaginationLimitChange = async (limit) => {
   const newLimit = limit === 'View All' ? news.value?.total : limit
-  const response = await fetchNews($contentfulClient, route.query.search, publishedLessThanDate.value, publishedGreaterThanOrEqualToDate.value, subjects.value, sortOrder.value, newLimit, 0)
-  news.value = response
+  news.value = await fetchNewsItems(newLimit, 0)
 }
 
 const onSortOptionChange = async (option) => {
   selectedSortOption.value = option
-  const response = await fetchNews($contentfulClient, route.query.search, publishedLessThanDate.value, publishedGreaterThanOrEqualToDate.value, subjects.value, sortOrder.value, news.value.limit, 0)
-  news.value = response
+  news.value = await fetchNewsItems(
+    news.value?.limit || 10,
+    0,
+    propOr('-fields.publishedDate', 'sortOrder', option)
+  )
 }
 
 const altResultsMounted = () => {

--- a/pages/share-data/index.vue
+++ b/pages/share-data/index.vue
@@ -51,12 +51,9 @@ const breadcrumb = [
 ]
 const showLoginDialog = ref(false)
 
-const { data: pageData, error } = await useAsyncData('pageData', async () => {
-  const { $contentfulClient } = useNuxtApp()
-  const config = useRuntimeConfig()
-  const pageData = await $contentfulClient.getEntry(config.public.ctf_share_data_page_id)
-  return pageData.fields
-})
+const { data: pageData, error } = await useAsyncData('pageData', () =>
+  $fetch('/api/contentful/share-data-page').catch(() => null)
+)
 
 const title = computed(() => pageData.value?.title || '')
 const summary = computed(() => pageData.value?.summary || '')

--- a/pages/tools-and-resources/[resourceId].vue
+++ b/pages/tools-and-resources/[resourceId].vue
@@ -99,7 +99,7 @@ export default {
   async setup() {
     const { $contentfulClient } = useNuxtApp()
     const route = useRoute()
-    const resource = await $contentfulClient.getEntry(route.params.resourceId)
+    const resource = await $fetch(`/api/contentful/resource/${route.params.resourceId}`)
     const isTool = pathOr(false, ['fields', 'category'], resource)
     const parentPage = {
       label: isTool ? 'Tools' : 'Resources',

--- a/server/api/algolia/dataset-facets.get.js
+++ b/server/api/algolia/dataset-facets.get.js
@@ -1,0 +1,62 @@
+import algoliasearch from 'algoliasearch'
+
+const facetPropPathMapping = [
+  { label: 'Type', id: 'item.types', facetPropPath: 'item.types.name', facetSubpropPath: 'item.types.subcategory.name' },
+  { label: 'Anatomical Structure', id: 'anatomy.organ.category', facetPropPath: 'anatomy.organ.category.name', facetSubpropPath: 'anatomy.organ.subcategory.name' },
+  { label: 'Anatomical Structure', id: 'anatomy.organ', facetPropPath: 'anatomy.organ.name', facetSubpropPath: 'anatomy.organ.subcategory.name' },
+  { label: 'Species', id: 'organisms.primary.species', facetPropPath: 'organisms.primary.species.name', facetSubpropPath: 'organisms.primary.species.subcategory.name' },
+  { label: 'Experimental Approach', id: 'item.modalities', facetPropPath: 'item.modalities.keyword', facetSubpropPath: 'item.modalities.subcategory.name' },
+  { label: 'Sex', id: 'attributes.subject.sex', facetPropPath: 'attributes.subject.sex.value', facetSubpropPath: 'attributes.subject.sex.subcategory.name' },
+  { label: 'Age Categories', id: 'attributes.subject.ageCategory', facetPropPath: 'attributes.subject.ageCategory.value', facetSubpropPath: 'attributes.subject.ageCategory.subcategory.name' },
+  { label: 'Consortia', id: 'supportingAwards.consortium', facetPropPath: 'supportingAwards.consortium.name', facetSubpropPath: 'supportingAwards.consortium.subCategory.name' },
+]
+
+export default defineCachedEventHandler(async (event) => {
+  const id = getQuery(event).id
+  if (!id) throw createError({ statusCode: 400, message: 'id is required' })
+  const config = useRuntimeConfig()
+  const client = algoliasearch(config.public.ALGOLIA_APP_ID, config.public.ALGOLIA_API_KEY)
+  const index = client.initIndex(config.public.ALGOLIA_INDEX_PUBLISHED_TIME_DESC)
+
+  const facetPropPaths = facetPropPathMapping.map(item => item.facetPropPath)
+  const facetSubpropPaths = facetPropPathMapping.map(item => item.facetSubpropPath)
+
+  const response = await index.search('', {
+    hitsPerPage: 0,
+    sortFacetValuesBy: 'alpha',
+    facets: facetPropPaths.concat(facetSubpropPaths),
+    filters: `objectID:${id}`
+  })
+
+  const facetData = []
+  const responseFacets = response.facets || {}
+
+  facetPropPaths.forEach(facetPropPath => {
+    const parentFacet = facetPropPathMapping.find(item => item.facetPropPath === facetPropPath)
+    const responseFacetChildren = responseFacets[facetPropPath] || {}
+    const allPossibleChildrenSubfacets = parentFacet && responseFacets[parentFacet.facetSubpropPath]
+      ? Object.keys(responseFacets[parentFacet.facetSubpropPath])
+      : []
+
+    const children = Object.keys(responseFacetChildren).map(facet => {
+      const childrenSubfacets = allPossibleChildrenSubfacets.reduce((filtered, childFacetInfo) => {
+        const info = childFacetInfo.split('.')
+        if (info.length === 2 && facet === info[0]) {
+          filtered.push({ label: childFacetInfo, id: childFacetInfo, facetPropPath: parentFacet?.facetSubpropPath })
+        }
+        return filtered
+      }, [])
+      return { label: facet, id: facet, children: childrenSubfacets, facetPropPath }
+    })
+
+    if (children.length > 0) {
+      facetData.push({ label: parentFacet?.label || '', id: parentFacet?.label || '', children, key: facetPropPath })
+    }
+  })
+
+  return facetData
+}, {
+  maxAge: 30 * 60,
+  name: 'algolia-dataset-facets',
+  getKey: (event) => `dataset-facets-${getQuery(event).id}`
+})

--- a/server/api/algolia/dataset-metadata.get.js
+++ b/server/api/algolia/dataset-metadata.get.js
@@ -1,0 +1,14 @@
+import algoliasearch from 'algoliasearch'
+
+export default defineCachedEventHandler(async (event) => {
+  const id = getQuery(event).id
+  if (!id) throw createError({ statusCode: 400, message: 'id is required' })
+  const config = useRuntimeConfig()
+  const client = algoliasearch(config.public.ALGOLIA_APP_ID, config.public.ALGOLIA_API_KEY)
+  const index = client.initIndex(config.public.ALGOLIA_INDEX_PUBLISHED_TIME_DESC)
+  return await index.getObject(id)
+}, {
+  maxAge: 30 * 60,
+  name: 'algolia-dataset-metadata',
+  getKey: (event) => `dataset-metadata-${getQuery(event).id}`
+})

--- a/server/api/algolia/facets.get.js
+++ b/server/api/algolia/facets.get.js
@@ -1,0 +1,16 @@
+import algoliasearch from 'algoliasearch'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = algoliasearch(config.public.ALGOLIA_APP_ID, config.public.ALGOLIA_API_KEY)
+  const index = client.initIndex(config.public.ALGOLIA_INDEX_VERSION_PUBLISHED_TIME_DESC)
+  const result = await index.search('', {
+    hitsPerPage: 0,
+    facets: ['item.modalities.keyword', 'anatomy.organ.category.name', 'organisms.primary.species.name', 'supportingAwards.consortium.name'],
+  })
+  return { facets: result.facets || {}, nbHits: result.nbHits || 0 }
+}, {
+  maxAge: 60 * 60,
+  name: 'algolia-facets',
+  getKey: () => 'facets'
+})

--- a/server/api/algolia/organization-ids.get.js
+++ b/server/api/algolia/organization-ids.get.js
@@ -1,0 +1,17 @@
+import algoliasearch from 'algoliasearch'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = algoliasearch(config.public.ALGOLIA_APP_ID, config.public.ALGOLIA_API_KEY)
+  const index = client.initIndex(config.public.ALGOLIA_INDEX_PUBLISHED_TIME_DESC)
+  const { facets } = await index.search('', {
+    hitsPerPage: 0,
+    sortFacetValuesBy: 'alpha',
+    facets: 'pennsieve.organization.identifier',
+  })
+  return Object.keys(facets?.['pennsieve.organization.identifier'] || {})
+}, {
+  maxAge: 60 * 60,
+  name: 'algolia-organization-ids',
+  getKey: () => 'organization-ids'
+})

--- a/server/api/contentful/about-consortia.get.js
+++ b/server/api/contentful/about-consortia.get.js
@@ -1,0 +1,20 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const { items } = await client.getEntries({
+    content_type: config.public.ctf_consortia_content_type_id,
+    order: 'fields.displayOrder',
+    'fields.displayOnAboutPage': true
+  })
+  return items
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-about-consortia',
+  getKey: () => 'about-consortia'
+})

--- a/server/api/contentful/about-details/[slug].get.js
+++ b/server/api/contentful/about-details/[slug].get.js
@@ -1,0 +1,23 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async (event) => {
+  const slug = getRouterParam(event, 'slug')
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const entries = await client.getEntries({
+    content_type: config.public.ctf_about_details_content_type_id,
+    'fields.slug': slug
+  })
+  if (entries.items.length > 0) return { item: entries.items[0], foundBySlug: true }
+  // Fallback: treat slug as a sys.id
+  const entry = await client.getEntry(slug)
+  return { item: entry, foundBySlug: false }
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-about-details',
+  getKey: (event) => `about-details-${getRouterParam(event, 'slug')}`
+})

--- a/server/api/contentful/about-page.get.js
+++ b/server/api/contentful/about-page.get.js
@@ -1,0 +1,16 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const entry = await client.getEntry(config.public.ctf_about_page_id)
+  return entry.fields
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-about-page',
+  getKey: () => 'about-page'
+})

--- a/server/api/contentful/apps-page.get.js
+++ b/server/api/contentful/apps-page.get.js
@@ -1,0 +1,16 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const entry = await client.getEntry(config.public.ctf_apps_page_id)
+  return entry
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-apps-page',
+  getKey: () => 'apps-page'
+})

--- a/server/api/contentful/community-spotlight-items.get.js
+++ b/server/api/contentful/community-spotlight-items.get.js
@@ -1,0 +1,28 @@
+import contentful from 'contentful'
+import { getQuery } from 'h3'
+
+const CTF_COMMUNITY_SPOTLIGHT_ITEM_ID = 'communitySpotlight'
+
+export default defineEventHandler(async (event) => {
+  const { search, spotlightTypes, anatomicalStructures, sortOrder, limit = 10, skip = 0 } = getQuery(event)
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  try {
+    return await client.getEntries({
+      content_type: CTF_COMMUNITY_SPOTLIGHT_ITEM_ID,
+      order: sortOrder || '-fields.publishedDate',
+      query: search || undefined,
+      limit: parseInt(limit),
+      skip: parseInt(skip),
+      'fields.itemType[in]': spotlightTypes || undefined,
+      'fields.anatomicalStructure[in]': anatomicalStructures || undefined
+    })
+  } catch (e) {
+    console.error(e)
+    return {}
+  }
+})

--- a/server/api/contentful/community-spotlight-types.get.js
+++ b/server/api/contentful/community-spotlight-types.get.js
@@ -1,0 +1,27 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const contentType = await client.getContentType('communitySpotlight')
+  let anatomicalStructures = {}
+  contentType.fields.forEach(field => {
+    if (field.id === 'anatomicalStructure') {
+      const structures = field.items?.validations[0]['in']
+      anatomicalStructures = {
+        label: 'Focus',
+        id: 'spotlightAnatomicalStructure',
+        data: structures.map(itemLabel => ({ label: itemLabel, id: itemLabel }))
+      }
+    }
+  })
+  return anatomicalStructures
+}, {
+  maxAge: 60 * 60 * 6,
+  name: 'contentful-community-spotlight-types',
+  getKey: () => 'community-spotlight-types'
+})

--- a/server/api/contentful/consortia-item/[id].get.js
+++ b/server/api/contentful/consortia-item/[id].get.js
@@ -14,7 +14,7 @@ export default defineCachedEventHandler(async (event) => {
   })
   return items[0] || null
 }, {
-  maxAge: 60 * 60,
+  maxAge: 60 * 30,
   name: 'contentful-consortia-item',
   getKey: (event) => `consortia-item-${getRouterParam(event, 'id')}`
 })

--- a/server/api/contentful/consortia-item/[id].get.js
+++ b/server/api/contentful/consortia-item/[id].get.js
@@ -1,0 +1,20 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async (event) => {
+  const slug = getRouterParam(event, 'id')
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const { items } = await client.getEntries({
+    content_type: config.public.ctf_consortia_content_type_id,
+    'fields.slug': slug.toLowerCase(),
+  })
+  return items[0] || null
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-consortia-item',
+  getKey: (event) => `consortia-item-${getRouterParam(event, 'id')}`
+})

--- a/server/api/contentful/consortia-news/[id].get.js
+++ b/server/api/contentful/consortia-news/[id].get.js
@@ -16,7 +16,7 @@ export default defineCachedEventHandler(async (event) => {
   })
   return items
 }, {
-  maxAge: 60 * 60,
+  maxAge: 60 * 30,
   name: 'contentful-consortia-news',
   getKey: (event) => `consortia-news-${getRouterParam(event, 'id')}`
 })

--- a/server/api/contentful/consortia-news/[id].get.js
+++ b/server/api/contentful/consortia-news/[id].get.js
@@ -1,0 +1,22 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async (event) => {
+  const slug = getRouterParam(event, 'id')
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const { items } = await client.getEntries({
+    content_type: config.public.ctf_news_id,
+    order: '-fields.publishedDate',
+    limit: 999,
+    'fields.consortiaHighlight[in]': slug.toLowerCase(),
+  })
+  return items
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-consortia-news',
+  getKey: (event) => `consortia-news-${getRouterParam(event, 'id')}`
+})

--- a/server/api/contentful/contact-us-form-types.get.js
+++ b/server/api/contentful/contact-us-form-types.get.js
@@ -1,0 +1,18 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const { items } = await client.getEntries({
+    content_type: config.public.ctf_contact_us_form_type_id,
+  })
+  return items.map(item => ({ id: item.sys.id, label: item.fields.title, description: item.fields.description }))
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-contact-us-form-types',
+  getKey: () => 'contact-us-form-types'
+})

--- a/server/api/contentful/entry/[id].get.js
+++ b/server/api/contentful/entry/[id].get.js
@@ -1,0 +1,16 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  return await client.getEntry(id)
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-entry',
+  getKey: (event) => `entry-${getRouterParam(event, 'id')}`
+})

--- a/server/api/contentful/event/[id].get.js
+++ b/server/api/contentful/event/[id].get.js
@@ -1,0 +1,24 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const isSlug = id.split('-').length > 1
+  if (isSlug) {
+    const { items } = await client.getEntries({
+      content_type: config.public.ctf_event_id,
+      'fields.slug': id
+    })
+    return items[0] || null
+  }
+  return await client.getEntry(id)
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-event',
+  getKey: (event) => `event-${getRouterParam(event, 'id')}`
+})

--- a/server/api/contentful/event/[id].get.js
+++ b/server/api/contentful/event/[id].get.js
@@ -18,7 +18,7 @@ export default defineCachedEventHandler(async (event) => {
   }
   return await client.getEntry(id)
 }, {
-  maxAge: 60 * 60,
+  maxAge: 60 * 30,
   name: 'contentful-event',
   getKey: (event) => `event-${getRouterParam(event, 'id')}`
 })

--- a/server/api/contentful/events-items.get.js
+++ b/server/api/contentful/events-items.get.js
@@ -1,0 +1,27 @@
+import contentful from 'contentful'
+import { getQuery } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  const { search, startLessThan, startGte, eventTypes, sortOrder, limit = 10, skip = 0 } = getQuery(event)
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  try {
+    return await client.getEntries({
+      content_type: 'event',
+      order: sortOrder || '-fields.startDate',
+      query: search || undefined,
+      limit: parseInt(limit),
+      skip: parseInt(skip),
+      'fields.startDate[lt]': startLessThan || undefined,
+      'fields.startDate[gte]': startGte || undefined,
+      'fields.eventType[in]': eventTypes || undefined
+    })
+  } catch (e) {
+    console.error(e)
+    return {}
+  }
+})

--- a/server/api/contentful/featured-data-categories.get.js
+++ b/server/api/contentful/featured-data-categories.get.js
@@ -1,0 +1,22 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const contentType = await client.getContentType('featuredData')
+  let categories = []
+  contentType.fields.forEach(field => {
+    if (field.id === 'facetType') {
+      categories = field.items?.validations[0]['in']
+    }
+  })
+  return categories
+}, {
+  maxAge: 60 * 60 * 6,
+  name: 'contentful-featured-data-categories',
+  getKey: () => 'featured-data-categories'
+})

--- a/server/api/contentful/footer-data.get.js
+++ b/server/api/contentful/footer-data.get.js
@@ -1,0 +1,17 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const response = await client.getEntry(config.public.ctf_home_page_id)
+  const { footerDescription, learnMoreLinks, policiesLinks, helpUsImproveLinks, stayUpdatedLinks } = response.fields
+  return { footerDescription, learnMoreLinks, policiesLinks, helpUsImproveLinks, stayUpdatedLinks }
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-footer-data',
+  getKey: () => 'footer-data'
+})

--- a/server/api/contentful/form-options.get.js
+++ b/server/api/contentful/form-options.get.js
@@ -1,0 +1,23 @@
+import contentful from 'contentful'
+import { propOr } from 'ramda'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const response = await client.getEntry(config.public.ctf_contact_us_form_options_id)
+  const fields = response.fields
+  return {
+    userTypes: propOr([], 'typeOfUser', fields),
+    areasOfSparc: propOr([], 'areaOfSparcPortal', fields),
+    services: propOr([], 'services', fields),
+    resourceCategories: propOr([], 'resourceCategories', fields),
+  }
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-form-options',
+  getKey: () => 'form-options'
+})

--- a/server/api/contentful/highlights.get.js
+++ b/server/api/contentful/highlights.get.js
@@ -1,0 +1,21 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const { items } = await client.getEntries({
+    content_type: config.public.ctf_news_id,
+    order: '-fields.publishedDate',
+    limit: 999,
+    'fields.subject': 'Highlight'
+  })
+  return items
+}, {
+  maxAge: 60 * 30,
+  name: 'contentful-highlights',
+  getKey: () => 'highlights'
+})

--- a/server/api/contentful/homepage-consortia.get.js
+++ b/server/api/contentful/homepage-consortia.get.js
@@ -1,0 +1,20 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const { items } = await client.getEntries({
+    content_type: config.public.ctf_consortia_content_type_id,
+    order: 'fields.displayOrder',
+    'fields.displayOnHomepage': true,
+  })
+  return items
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-homepage-consortia',
+  getKey: () => 'homepage-consortia'
+})

--- a/server/api/contentful/homepage.get.js
+++ b/server/api/contentful/homepage.get.js
@@ -1,0 +1,15 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  return await client.getEntry(config.public.ctf_home_page_id)
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-homepage',
+  getKey: () => 'homepage'
+})

--- a/server/api/contentful/news-and-events.get.js
+++ b/server/api/contentful/news-and-events.get.js
@@ -30,7 +30,7 @@ export default defineCachedEventHandler(async () => {
   ])
   return { upcomingEvents, news, page, stories }
 }, {
-  maxAge: 60 * 60,
+  maxAge: 60 * 15,
   name: 'contentful-news-and-events',
   getKey: () => 'news-and-events'
 })

--- a/server/api/contentful/news-and-events.get.js
+++ b/server/api/contentful/news-and-events.get.js
@@ -1,0 +1,36 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const todaysDate = new Date()
+  const [upcomingEvents, news, page, stories] = await Promise.all([
+    client.getEntries({
+      content_type: config.public.ctf_event_id,
+      order: 'fields.startDate',
+      'fields.startDate[gte]': todaysDate.toISOString(),
+      limit: 2
+    }),
+    client.getEntries({
+      content_type: config.public.ctf_news_id,
+      order: '-fields.publishedDate',
+      limit: 2
+    }),
+    client.getEntry(config.public.ctf_news_and_events_page_id),
+    client.getEntries({
+      content_type: 'communitySpotlight',
+      order: '-fields.publishedDate',
+      limit: 2,
+      skip: 0
+    })
+  ])
+  return { upcomingEvents, news, page, stories }
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-news-and-events',
+  getKey: () => 'news-and-events'
+})

--- a/server/api/contentful/news-items.get.js
+++ b/server/api/contentful/news-items.get.js
@@ -1,0 +1,27 @@
+import contentful from 'contentful'
+import { getQuery } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  const { search, publishedLessThan, publishedGte, subjects, sortOrder, limit = 10, skip = 0 } = getQuery(event)
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  try {
+    return await client.getEntries({
+      content_type: 'news',
+      order: sortOrder || '-fields.publishedDate',
+      query: search || undefined,
+      limit: parseInt(limit),
+      skip: parseInt(skip),
+      'fields.publishedDate[lt]': publishedLessThan || undefined,
+      'fields.publishedDate[gte]': publishedGte || undefined,
+      'fields.subject[in]': subjects || undefined
+    })
+  } catch (e) {
+    console.error(e)
+    return {}
+  }
+})

--- a/server/api/contentful/portal-notification.get.js
+++ b/server/api/contentful/portal-notification.get.js
@@ -1,0 +1,16 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const response = await client.getEntry(config.public.ctf_portal_notification_entry_id)
+  return response.fields
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-portal-notification',
+  getKey: () => 'portal-notification'
+})

--- a/server/api/contentful/project/[id].get.js
+++ b/server/api/contentful/project/[id].get.js
@@ -1,0 +1,17 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const entry = await client.getEntry(id)
+  return entry
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-project',
+  getKey: (event) => `project-${getRouterParam(event, 'id')}`
+})

--- a/server/api/contentful/projects.get.js
+++ b/server/api/contentful/projects.get.js
@@ -1,0 +1,18 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const { items } = await client.getEntries({
+    content_type: config.public.ctf_project_id,
+  })
+  return items
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-projects',
+  getKey: () => 'projects'
+})

--- a/server/api/contentful/resource/[id].get.js
+++ b/server/api/contentful/resource/[id].get.js
@@ -1,0 +1,17 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const entry = await client.getEntry(id)
+  return entry
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-resource',
+  getKey: (event) => `resource-${getRouterParam(event, 'id')}`
+})

--- a/server/api/contentful/share-data-page.get.js
+++ b/server/api/contentful/share-data-page.get.js
@@ -1,0 +1,16 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const entry = await client.getEntry(config.public.ctf_share_data_page_id)
+  return entry.fields
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-share-data-page',
+  getKey: () => 'share-data-page'
+})

--- a/server/api/contentful/sparc-award-types.get.js
+++ b/server/api/contentful/sparc-award-types.get.js
@@ -1,0 +1,26 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  let projectsAnatomicalFocusFacets = []
+  let consortiaTypes = []
+  const contentType = await client.getContentType('sparcAward')
+  contentType.fields.forEach(field => {
+    if (field.name === 'Funding') {
+      consortiaTypes = (field.items?.validations[0]['in'] || []).map(label => ({ label, id: label }))
+    }
+    if (field.name === 'Focus') {
+      projectsAnatomicalFocusFacets = (field.items?.validations[0]['in'] || []).map(label => ({ label, id: label }))
+    }
+  })
+  return { projectsAnatomicalFocusFacets, consortiaTypes }
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-sparc-award-types',
+  getKey: () => 'sparc-award-types'
+})

--- a/server/api/contentful/sparc-award-types.get.js
+++ b/server/api/contentful/sparc-award-types.get.js
@@ -20,7 +20,7 @@ export default defineCachedEventHandler(async () => {
   })
   return { projectsAnatomicalFocusFacets, consortiaTypes }
 }, {
-  maxAge: 60 * 60,
+  maxAge: 60 * 60 * 6,
   name: 'contentful-sparc-award-types',
   getKey: () => 'sparc-award-types'
 })

--- a/server/api/contentful/sparc-dashboard.get.js
+++ b/server/api/contentful/sparc-dashboard.get.js
@@ -1,0 +1,15 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async () => {
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  return await client.getEntry(config.public.ctf_sparc_dashboard_entry_id)
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-sparc-dashboard',
+  getKey: () => 'sparc-dashboard'
+})

--- a/server/api/contentful/success-story/[id].get.js
+++ b/server/api/contentful/success-story/[id].get.js
@@ -1,0 +1,22 @@
+import contentful from 'contentful'
+
+export default defineCachedEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+  const config = useRuntimeConfig()
+  const client = contentful.createClient({
+    space: config.public.CTF_SPACE_ID,
+    accessToken: config.public.CTF_CDA_ACCESS_TOKEN,
+    host: config.public.CTF_API_HOST || 'preview.contentful.com'
+  })
+  const { items } = await client.getEntries({
+    content_type: 'successStoryDisplay',
+    'fields.storyRoute[match]': id,
+    include: 1,
+    order: '-fields.publishedDate',
+  })
+  return items[0]?.fields || {}
+}, {
+  maxAge: 60 * 60,
+  name: 'contentful-success-story',
+  getKey: (event) => `success-story-${getRouterParam(event, 'id')}`
+})

--- a/server/api/contentful/success-story/[id].get.js
+++ b/server/api/contentful/success-story/[id].get.js
@@ -16,7 +16,7 @@ export default defineCachedEventHandler(async (event) => {
   })
   return items[0]?.fields || {}
 }, {
-  maxAge: 60 * 60,
+  maxAge: 60 * 30,
   name: 'contentful-success-story',
   getKey: (event) => `success-story-${getRouterParam(event, 'id')}`
 })

--- a/server/middleware/validateParams.js
+++ b/server/middleware/validateParams.js
@@ -1,0 +1,60 @@
+// Rejects requests with SQL injection patterns or invalid paths before SSR runs.
+// Prevents Algolia/Contentful calls being triggered by scanner traffic.
+
+const SQL_PATTERNS = [
+  /%2525/,                                       // double-encoded % — WAF bypass attempts
+  /union[\s\/*]+(?:all[\s\/*]+)?select/i,        // UNION [ALL] SELECT
+  /extractvalue\s*\(/i,                           // EXTRACTVALUE( — MySQL error injection
+  /xmltype\s*\(/i,                                // XMLType( — Oracle error injection
+  /cast\s*\(\s*['0]/i,                            // CAST('~ or CAST(0x — type coercion injection
+  /0x[0-9a-f]{6,}/i,                              // long hex literals e.g. 0x717a7171
+  /'\s*(?:and|or)\s+[\w\d]+\s*=\s*[\w\d]+/i,     // ' AND 1=1 / ' OR 1=1
+  /'\s*(?:and|or)\s+[\w\d]+\s+in\s*\(/i,         // ' AND x IN (SELECT...
+]
+
+// Paths that will never exist on this Node.js server — reject immediately without SSR.
+const BAD_PATH_PATTERNS = [
+  /\.php(\?|$)/i,           // PHP file scans (webshells, WordPress exploits)
+  /\/wp-(?:content|admin|includes|login|json)\//i,  // WordPress path scans
+  /\.env(\.|$)/i,           // Environment file probes (.env, .env.backup, etc.)
+  /\/vendor\/phpunit\//i,   // PHP unit exploit path
+  /\/xmlrpc\.php/i,         // WordPress XML-RPC
+  /\/adminer\.php/i,        // Adminer DB tool
+  /\/phpmyadmin/i,          // phpMyAdmin
+]
+
+function reject(event, status) {
+  const res = event.node.res
+  res.statusCode = status
+  res.end('Invalid request.')
+}
+
+export default defineEventHandler((event) => {
+  const url = event?.node?.req?.url || ''
+  const path = url.split('?')[0]
+
+  // Block path-based scanner probes immediately (no PHP/WordPress on this server)
+  if (BAD_PATH_PATTERNS.some(pattern => pattern.test(path))) {
+    reject(event, 404)
+    return
+  }
+
+  // Block SQL injection in query parameters
+  const queryStart = url.indexOf('?')
+  if (queryStart === -1) return
+
+  const rawQuery = url.slice(queryStart + 1)
+  let decoded = rawQuery
+  try {
+    decoded = decodeURIComponent(rawQuery)
+  } catch {
+    // malformed encoding — block it
+    reject(event, 400)
+    return
+  }
+
+  if (SQL_PATTERNS.some(pattern => pattern.test(decoded) || pattern.test(rawQuery))) {
+    reject(event, 400)
+    return
+  }
+})

--- a/server/middleware/webCrawlers.js
+++ b/server/middleware/webCrawlers.js
@@ -4,9 +4,10 @@ export default defineEventHandler((event) => {
   const userAgent = req?.headers['user-agent']?.toLowerCase() || ''
   const url = req?.url || ''
 
-  // Skip blocking for sitemap API
-  if (url.startsWith('/api/__sitemap__/urls') || url.startsWith('/__sitemap__/')) {
-    return // allow sitemap requests through
+  // Skip blocking for API routes — includes internal SSR $fetch calls (no user-agent by design)
+  // and sitemap routes. Bot quota protection on API endpoints is handled by Nitro cache TTL.
+  if (url.startsWith('/api/') || url.startsWith('/__sitemap__/')) {
+    return
   }
   
   const botPatterns = [
@@ -23,8 +24,19 @@ export default defineEventHandler((event) => {
     /screaming frog seo spider/i, /adsbot-google/i, /sogou/i
   ]
 
-  if (userAgent == '' || botPatterns.some(pattern => pattern.test(userAgent))) {
-    console.log(`Blocked bot: ${userAgent} from IP: ${getRequestIP(event)}`)
+  const ip = req?.headers['x-forwarded-for']?.split(',')[0]?.trim()
+    || req?.socket?.remoteAddress
+    || 'unknown'
+
+  if (userAgent == '') {
+    console.log(`Blocked request with no user-agent from IP: ${ip}`)
+    res.statusCode = 403
+    res.end('Bot detected, serving 403 response.')
+    return
+  }
+
+  if (botPatterns.some(pattern => pattern.test(userAgent))) {
+    console.log(`Blocked bot: ${userAgent} from IP: ${ip}`)
     res.statusCode = 403
     res.end('Bot detected, serving 403 response.')
     return

--- a/store/index.js
+++ b/store/index.js
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import auth from '@/services/auth.js'
-import { pathOr, propOr } from 'ramda'
+import { pathOr } from 'ramda'
 
 export const useMainStore = defineStore('main', {
   state: () => ({
@@ -26,10 +26,10 @@ export const useMainStore = defineStore('main', {
       return `${firstName} ${abbrvLastName}`
     },
     userToken(state) {
-      return propOr('', 'token', state.userProfile)
+      return state.userProfile?.token ?? ''
     },
     tokenExp(state) {
-      return propOr('', 'tokenExp', state.userProfile)
+      return state.userProfile?.tokenExp ?? ''
     },
     firstName (state) {
       return pathOr('', ['firstName'], state.userProfile)
@@ -62,8 +62,7 @@ export const useMainStore = defineStore('main', {
   actions: {
     async init() {
       const appInitializedCookie = useCookie('appInitialized')
-      if (appInitializedCookie.value === 'true') {
-        console.log('App already initialized')
+      if (!import.meta.server && appInitializedCookie.value === 'true') {
         return
       }
       try {
@@ -100,89 +99,35 @@ export const useMainStore = defineStore('main', {
       this.formOptions = value
     },
     async fetchContactUsFormOptions() {
-      const { data, error } = await useAsyncData(
+      const { data } = await useAsyncData(
         'contact-us-form-options',
-        async () => {
-          try {
-            const response = await useNuxtApp().$contentfulClient.getEntry(
-              useRuntimeConfig().public.ctf_contact_us_form_options_id
-            )
-            const fields = response.fields
-  
-            const formOptions = {
-              userTypes: propOr([], 'typeOfUser', fields),
-              areasOfSparc: propOr([], 'areaOfSparcPortal', fields),
-              services: propOr([], 'services', fields),
-              resourceCategories: propOr([], 'resourceCategories', fields),
-            }
-            return formOptions
-          } catch (e) {
-            console.error(e)
-            return null
-          }
-        },
-        {
-          server: true
-        }
+        () => $fetch('/api/contentful/form-options').catch(() => null),
+        { server: true }
       )
-
-      if (data) {
-        this.setFormOptions(data)
+      if (data.value) {
+        this.setFormOptions(data.value)
       }
     },
 
     async fetchPortalNotification() {
-      const { data, error } = await useAsyncData(
+      const { data } = await useAsyncData(
         'portal-notification',
-        async () => {
-          try {
-            const response = await useNuxtApp().$contentfulClient.getEntry(
-              useRuntimeConfig().public.ctf_portal_notification_entry_id
-            )
-            return response.fields
-          } catch (e) {
-            console.error(e)
-            return null
-          }
-        },
-        {
-          server: true
-        }
+        () => $fetch('/api/contentful/portal-notification').catch(() => null),
+        { server: true }
       )
-
-      if (data) {
-        this.setPortalNotification(data)
+      if (data.value) {
+        this.setPortalNotification(data.value)
       }
     },
 
     async fetchFooterData() {
-      const { data, error } = await useAsyncData(
+      const { data } = await useAsyncData(
         'footer-data',
-        async () => {
-          try {
-            const response = await useNuxtApp().$contentfulClient.getEntry(
-              useRuntimeConfig().public.ctf_home_page_id
-            )
-            const { footerDescription, learnMoreLinks, policiesLinks, helpUsImproveLinks, stayUpdatedLinks } = response.fields
-            return {
-              footerDescription,
-              learnMoreLinks,
-              policiesLinks,
-              helpUsImproveLinks,
-              stayUpdatedLinks,
-            }
-          } catch (e) {
-            console.error(e)
-            return null
-          }
-        },
-        {
-          server: true
-        }
+        () => $fetch('/api/contentful/footer-data').catch(() => null),
+        { server: true }
       )
-
-      if (data) {
-        this.setFooterData(data)
+      if (data.value) {
+        this.setFooterData(data.value)
       }
     },
     setUserProfile(value) {
@@ -197,6 +142,7 @@ export const useMainStore = defineStore('main', {
   },
   persist: {
     storage: persistedState.localStorage,
+    omit: ['footerData', 'portalNotification'],
   }
 })
 


### PR DESCRIPTION
Bot traffic was triggering server-side Contentful and Algolia API calls on every page render, exhausting API quota. Two middleware layers now block bots before SSR runs, and 32 Nitro server API endpoints cache all external API responses so repeated hits are served from memory instead of hitting upstream services.

Problem

Malicious traffic was causing every SSR page render to make direct calls to the Contentful and Algolia APIs. Because each render consumed quota regardless of whether the visitor was a real user, heavy crawler activity was exhausting API limits and causing service degradation.

Solution

Three layers of defense were added:

Layer 1 — Request blocking (middleware)

server/middleware/validateParams.js (new)
Rejects requests before SSR runs if they match SQL injection patterns or known scanner probes (WordPress paths, .php files, .env probes, etc.).

server/middleware/webCrawlers.js (updated)
Blocks 44+ known bot user-agents with a 403. Empty user-agents are also blocked. /api/ and /__sitemap__/ routes are exempted so internal SSR $fetch calls (which carry no user-agent by design) are never blocked.

Layer 2 — Cached server API endpoints (new)

32 Nitro server API handlers under server/api/contentful/ and server/api/algolia/ replace direct client calls in pages. All use defineCachedEventHandler with TTLs appropriate to how frequently the data changes:

- 6 hours — content type schemas (rarely change)
- 1 hour — static page content, project/resource entries
- 30 minutes — consortium/news/event entries
- 15 minutes — time-sensitive data (upcoming events)
- No cache — parameterised user searches (news, events, community spotlight items) where the response varies by filter

Layer 3 — Pages updated to use server APIs

All pages that previously called $contentfulClient or $algoliaClient directly during SSR were updated to use $fetch('/api/...') instead. For interactive/search pages where SSR content has no value, import.meta.server guards prevent any external API calls during server rendering.

Additional fixes

- store/index.js — added !import.meta.server guard to prevent double-initialisation during SSR; added omit: ['footerData', 'portalNotification'] to the persist config to prevent hydration mismatches
- pages/about/index.vue — fixed TypeError on nested Algolia metrics key access with optional chaining