### PR TITLE
Update mapviewer to version 1.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "semver": "^7.7.3"
   },
   "dependencies": {
-    "@abi-software/mapintegratedvuer": "1.19.0",
+    "@abi-software/mapintegratedvuer": "1.19.1",
     "@abi-software/plotcomponents": "^0.2.4",
     "@abi-software/plotdatahelpers": "^0.1.2",
     "@abi-software/simulationvuer": "3.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,10 +36,10 @@
     unplugin-vue-components "^0.26.0"
     vue "^3.4.21"
 
-"@abi-software/map-side-bar@^2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-2.15.0.tgz#6b4ca59bbbe0390ff83d66ce71bd3706bbbbe62f"
-  integrity sha512-ju7Cnzc+oYnoRNwuadsW859Yvf6H8kqxbp14be3Rw/BHm9Kllr4d5g3S8JXKwo0PqV/CW6vfF7R+xU6c/EKdWg==
+"@abi-software/map-side-bar@^2.15.1":
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/map-side-bar/-/map-side-bar-2.15.1.tgz#e30c305b933b66c717f70b3f2967f2b094424d9a"
+  integrity sha512-2sEQpakTSXLRjpuMqJZ5w0GoU1caQMCayQ4LwUvZ98ZKrjsxCFX5wfN0phxlDS7V76YpVbtPFDdjrDEMbQzf0A==
   dependencies:
     "@abi-software/gallery" "1.3.0"
     "@abi-software/map-utilities" "1.8.3"
@@ -67,13 +67,13 @@
     mitt "^3.0.1"
     vue "^3.4.21"
 
-"@abi-software/mapintegratedvuer@1.19.0":
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.19.0.tgz#00acc272efb6d8343c32fa968e9210dc27dffe93"
-  integrity sha512-bieOU/Jxi6KQHoXQJiurdxCSx7otmRd5tRtjGIzMk79UGkzRnTndc9lVIZeYQJkglLCpxIE2gNs30Oki+mD/Vg==
+"@abi-software/mapintegratedvuer@1.19.1":
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/@abi-software/mapintegratedvuer/-/mapintegratedvuer-1.19.1.tgz#66a1b62a5af1fc340e37b425906aa4f23d27b545"
+  integrity sha512-u4TEKEYpUER4iSEY/2wlLYcJbsGa40j4bDDT/3TyRPsKN/pL9Kp16K+XjCZIfJz7UXuOeCKNXiKJvmzbnOqyFQ==
   dependencies:
     "@abi-software/flatmapvuer" "1.13.4"
-    "@abi-software/map-side-bar" "^2.15.0"
+    "@abi-software/map-side-bar" "^2.15.1"
     "@abi-software/map-utilities" "1.8.3"
     "@abi-software/plotvuer" "1.0.7"
     "@abi-software/scaffoldvuer" "1.17.0"


### PR DESCRIPTION
Update mapviewer version 1.19.1.

Bug fix:
Add missing space in copied content for expert consultants information.

This has been deployed here - https://alan-wu-sparc-app.herokuapp.com/apps/maps?type=ac