### PR TITLE
Fix dataset files fetching with limit

### DIFF
--- a/mixins/fetch-pennsieve-file/index.js
+++ b/mixins/fetch-pennsieve-file/index.js
@@ -6,9 +6,9 @@ export default {
      * Workaround to using pennsieve endpoint https://docs.pennsieve.io/reference/getfile-1 to get the file
      * we can replace this once the discrepencies between the getFile and browseFiles pennsieve endpoint responses are figured out
      * for files containing multiple extensions.
-     * 
+     *
      * errorReporting is the nuxt error callable object which will be called when the method encounter an error
-     * or no file can be found and cause the error page to render 
+     * or no file can be found and cause the error page to render
      */
     fetchPennsieveFile: async function(filePath, datasetId, datasetVersion, errorReporting) {
       try {
@@ -17,8 +17,25 @@ export default {
         const fileLocationEndIndex = filePath.lastIndexOf('/')
         const filesLocation = filePath.substring(0, fileLocationEndIndex)
         const filesUrl = `${config.public.discover_api_host}/datasets/${datasetId}/versions/${datasetVersion}/files/browse`
-        const filesResponse = await $pennsieveApiClient.value.get(filesUrl, { params: { path: filesLocation } })
-        const files = filesResponse.data.files
+        const limit = 200
+        let offset = 0
+        let files = []
+        let totalCount = Infinity
+
+        while (files.length < totalCount) {
+          const pageResponse = await $pennsieveApiClient.value.get(filesUrl, {
+            params: { path: filesLocation, limit, offset }
+          })
+          const page = pageResponse.data
+          const pageFiles = page?.files || []
+          totalCount = page?.totalCount ?? files.length
+          files = files.concat(pageFiles)
+
+          // Safety: if the API ever returns an empty page, stop to avoid an infinite loop
+          if (pageFiles.length === 0) break
+          offset += limit
+        }
+
         if (files.length === 0) {
           console.warn(`
           WARNING! the file "${filePath}" was just attempted to download from ${filesUrl} , This will likely crash the page using this file`)
@@ -46,7 +63,7 @@ export default {
           }
           return keepLooking
         })
-        
+
         if (errorReporting && (Object.keys(foundFile).length === 0)) {
           throw "File cannot be found"
         }

--- a/mixins/fetch-pennsieve-file/index.js
+++ b/mixins/fetch-pennsieve-file/index.js
@@ -17,52 +17,52 @@ export default {
         const fileLocationEndIndex = filePath.lastIndexOf('/')
         const filesLocation = filePath.substring(0, fileLocationEndIndex)
         const filesUrl = `${config.public.discover_api_host}/datasets/${datasetId}/versions/${datasetVersion}/files/browse`
-        const limit = 200
+        const limit = 100
         let offset = 0
-        let files = []
-        let totalCount = Infinity
+        let foundFile = {}
+        const searchFilePath = filePath.toLowerCase()
 
-        while (files.length < totalCount) {
+        // Fetch up to `limit` files per batch and search each batch for the matching file.
+        // Stop as soon as the file is found, or when there are no more files left to search.
+        while (Object.keys(foundFile).length === 0) {
           const pageResponse = await $pennsieveApiClient.value.get(filesUrl, {
             params: { path: filesLocation, limit, offset }
           })
           const page = pageResponse.data
           const pageFiles = page?.files || []
-          totalCount = page?.totalCount ?? files.length
-          files = files.concat(pageFiles)
+          const totalCount = page?.totalCount ?? pageFiles.length
 
-          // Safety: if the API ever returns an empty page, stop to avoid an infinite loop
-          if (pageFiles.length === 0) break
-          offset += limit
-        }
-
-        if (files.length === 0) {
-          console.warn(`
-          WARNING! the file "${filePath}" was just attempted to download from ${filesUrl} , This will likely crash the page using this file`)
-        }
-
-        filePath = filePath.toLowerCase()
-        let foundFile = {}
-        let keepLooking = true
-
-        files.every(file => {
-          // Check if path matches query param.
-          if (filePath.toLowerCase() == file.path.toLowerCase()) {
-            foundFile = file
-            keepLooking = false
-          } else if (file.uri) {
-            // Check if uri matches filePath query param.
-            let uriFile = file.uri.substring(file.uri.lastIndexOf('/'))
-            if (uriFile) {
-              uriFile = uriFile.toLowerCase()
-            }
-            if (filePath.includes(uriFile)) {
-              foundFile = file
-              keepLooking = false
-            }
+          // No more files left to search; terminate.
+          if (pageFiles.length === 0) {
+            console.warn(`
+            WARNING! the file "${filePath}" was just attempted to download from ${filesUrl} , This will likely crash the page using this file`)
+            break
           }
-          return keepLooking
-        })
+
+          // Look for the matching file within this batch.
+          foundFile = pageFiles.find(file => {
+            // Check if path matches query param.
+            if (searchFilePath == file.path.toLowerCase()) {
+              return true
+            } else if (file.uri) {
+              // Check if uri matches filePath query param.
+              let uriFile = file.uri.substring(file.uri.lastIndexOf('/'))
+              if (uriFile) {
+                uriFile = uriFile.toLowerCase()
+              }
+              if (searchFilePath.includes(uriFile)) {
+                return true
+              }
+            }
+            return false
+          }) || {}
+
+          // File not found in this batch; fetch the next one.
+          offset += limit
+          if (offset >= totalCount) {
+            break
+          }
+        }
 
         if (errorReporting && (Object.keys(foundFile).length === 0)) {
           throw "File cannot be found"

--- a/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
+++ b/pages/datasets/file/[datasetId]/[datasetVersion]/index.vue
@@ -1,6 +1,7 @@
 <template>
   <client-only>
-    <div class="pb-32 page-data">
+    <error400 v-if="!hasFile" />
+    <div class="pb-32 page-data" v-else>
       <breadcrumb :breadcrumb="breadcrumb" :title="fileName" />
       <div class="container">
         <h1 hidden>File viewer for {{ file.path }}</h1>
@@ -62,6 +63,7 @@ import FormatDate from '@/mixins/format-date'
 import FetchPennsieveFile from '@/mixins/fetch-pennsieve-file'
 import FileDetails from '@/mixins/file-details'
 import Gallery from '@/components/Gallery/Gallery.vue'
+import error400 from '@/components/Error/400.vue'
 
 import { extractS3BucketName } from '@/utils/common'
 
@@ -279,6 +281,10 @@ export default {
   },
 
   computed: {
+    hasFile: function() {
+      // `file` is an object; it is an empty object `{}` when no file was found.
+      return !isEmpty(this.file)
+    },
     hasViewer: function() {
       return this.hasSimulationViewer ||
         this.hasPlotViewer || this.hasVideoViewer || this.hasOmeViewer ||


### PR DESCRIPTION
**Problem**: `fetchPennsieveFile` made a single request to the Pennsieve `files/browse` endpoint, which returns max `100` files by default. Files past position `100` in a folder never matched, so the file viewer showed an empty page.

**Fix**: Added paginated fetching with early exit, fetch `100` files per batch, search for a match, stop if found; otherwise, fetch the next batch. Terminates when no files remain (using the API's [`totalCount`]). Common case stays at one request; large folders now work correctly.

Additionally, it shows the error block when the file is not found. I chose the 400-error block because it has a "submit a bug report" button. 

### Related issue

- https://github.com/nih-sparc/sparc-api/issues/318
